### PR TITLE
Compute absolute paths and use this to load files that aren't namespaced well

### DIFF
--- a/lib/business_time.rb
+++ b/lib/business_time.rb
@@ -1,6 +1,7 @@
 require "business_time/config"
 require "business_time/business_hours"
 require "business_time/business_days"
-require "extensions/date"
-require "extensions/time"
-require "extensions/fixnum"
+
+require File.dirname(__FILE__) +  "/extensions/date"
+require File.dirname(__FILE__) +  "/extensions/time"
+require File.dirname(__FILE__) + "/extensions/fixnum"


### PR DESCRIPTION
Using this gem with school_days causes a problem because of their similar folder structure: they both have:

extensions/
  date.rb
   fixnum.rb

require 'extensions/date.rb' was NOT loading business_time's date.rb (I can only guess it was loading school_days date.rb again).

This commit computes the absolute paths (via File.dirname(**FILE**)) to avoid these kinds of load errors
