### PR TITLE
Add since to business hours

### DIFF
--- a/lib/business_time/business_hours.rb
+++ b/lib/business_time/business_hours.rb
@@ -31,6 +31,7 @@ module BusinessTime
       end
       after_time
     end
+    alias_method :since, :after
 
     def before(time)
       before_time = Time.roll_forward(time)

--- a/test/test_business_hours.rb
+++ b/test/test_business_hours.rb
@@ -25,6 +25,13 @@ class TestBusinessHours < Test::Unit::TestCase
       assert_equal expected, monday_morning
     end
 
+    should "take into account a weekend when adding an hour, using the common interface #since" do
+      friday_afternoon = Time.parse("April 9th, 4:50 pm")
+      monday_morning = 1.business_hour.since(friday_afternoon)
+      expected = Time.parse("April 12th 2010, 9:50 am")
+      assert_equal expected, monday_morning
+    end
+
     should "take into account a weekend when subtracting an hour" do
       monday_morning = Time.parse("April 12th 2010, 9:50 am")
       friday_afternoon = 1.business_hour.before(monday_morning)


### PR DESCRIPTION
Added the since method to business hours. Two reasons:
1. business_days has it
2. ActiveSupport has it (but not #after)

Hope this helps!,
_Ryan Wilcox
