### PR TITLE
Fix holiday loading from config file

### DIFF
--- a/lib/business_time/config.rb
+++ b/lib/business_time/config.rb
@@ -71,8 +71,7 @@ module BusinessTime
       self.end_of_workday = data["business_time"]["end_of_workday"]
       self.work_week = data["business_time"]["work_week"]
       data["business_time"]["holidays"].each do |holiday|
-        self.holidays <<
-          Time.zone ? Time.zone.parse(holiday) : Time.parse(holiday)
+        self.holidays << (Time.zone ? Time.zone.parse(holiday) : Time.parse(holiday))
       end
       
     end


### PR DESCRIPTION
Holiday loading in BusinessTime::Config.load had a bug which caused holidays not to be properly loaded.
