### PR TITLE
Fix adding dates when starting during the weekend (fixes #14)

### DIFF
--- a/lib/business_time/business_days.rb
+++ b/lib/business_time/business_days.rb
@@ -9,10 +9,10 @@ module BusinessTime
 
     def after(time = Time.now)
       time = Time.zone ? Time.zone.parse(time.to_s) : Time.parse(time.to_s)
-      @days.times do
-        begin
-          time = time + 1.day
-        end until Time.workday?(time)
+      days = @days
+      while days > 0 || !Time.workday?(time)
+        days -= 1 if Time.workday?(time)
+        time = time + 1.day
       end
       time
     end
@@ -22,10 +22,10 @@ module BusinessTime
     
     def before(time = Time.now)
       time = Time.zone ? Time.zone.parse(time.to_s) : Time.parse(time.to_s)
-      @days.times do
-        begin
-          time = time - 1.day
-        end until Time.workday?(time)
+      days = @days
+      while days > 0 || !Time.workday?(time)
+        days -= 1 if Time.workday?(time)
+        time = time - 1.day
       end
       time
     end

--- a/test/test_business_days.rb
+++ b/test/test_business_days.rb
@@ -64,6 +64,21 @@ class TestBusinessDays < Test::Unit::TestCase
       expected = Time.parse("July 5th, 2010, 4:50 pm")
       assert_equal expected, monday_afternoon
     end
+
+    should "move to tuesday if we add one business day during a weekend" do
+      saturday = Time.parse("April 10th, 2010, 11:00 am")
+      later = 1.business_days.after(saturday)
+      expected = Time.parse("April 13th, 2010, 11:00 am")
+      assert_equal expected, later
+    end
+
+    should "move to thursday if we subtract one business day during a weekend" do
+      saturday = Time.parse("April 10th, 2010, 11:00 am")
+      before = 1.business_days.before(saturday)
+      expected = Time.parse("April 8th, 2010, 11:00 am")
+      assert_equal expected, before
+    end
+
   end
   
 end


### PR DESCRIPTION
When adding days to a date during a weekend, starting date
should be treated as first day after or last day before the weekend.

@bokmann I know that you were not sure if you want to pull that change, but we will probably use it in @mixbook, so I needed to make this fix anyway. I'll just leave it here in case you make your mind ;)
