### PR TITLE
Explicitly require HTTPS rubygems source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 gemspec


### PR DESCRIPTION
Require HTTPS rubygems.org to reduce the risk of MITM attacks
