### PR TITLE
Holidays can be specified by a type

### DIFF
--- a/lib/business_time/core_ext/date.rb
+++ b/lib/business_time/core_ext/date.rb
@@ -1,7 +1,7 @@
 # Add workday and weekday concepts to the Date class
 class Date
-  def workday?
-    self.weekday? && !BusinessTime::Config.holidays.include?(self)
+  def workday?(type = :common)
+    self.weekday? && !BusinessTime::Config.is_holiday?(self, type)
   end
   
   def weekday?

--- a/lib/business_time/core_ext/time.rb
+++ b/lib/business_time/core_ext/time.rb
@@ -22,9 +22,9 @@ class Time
 
     # True if this time is on a workday (between 00:00:00 and 23:59:59), even if
     # this time falls outside of normal business hours.
-    def workday?(day)
+    def workday?(day, type = :common)
       Time.weekday?(day) &&
-          !BusinessTime::Config.holidays.include?(day.to_date)
+          !BusinessTime::Config.is_holiday?(day.to_date, type)
     end
 
     # True if this time falls on a weekday.

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -17,8 +17,8 @@ class TestConfig < Test::Unit::TestCase
   should "keep track of holidays" do
     assert BusinessTime::Config.holidays.empty?
     daves_birthday = Date.parse("August 4th, 1969")
-    BusinessTime::Config.holidays << daves_birthday
-    assert BusinessTime::Config.holidays.include?(daves_birthday)
+    BusinessTime::Config.holidays[:common] << daves_birthday
+    assert BusinessTime::Config.holidays[:common].include?(daves_birthday)
   end
 
   should "keep track of work week" do
@@ -66,7 +66,7 @@ class TestConfig < Test::Unit::TestCase
     assert_equal "11:00 am", BusinessTime::Config.beginning_of_workday
     assert_equal "2:00 pm", BusinessTime::Config.end_of_workday
     assert_equal ['mon'], BusinessTime::Config.work_week
-    assert_equal [Date.parse('2012-12-25')], BusinessTime::Config.holidays
+    assert_equal [Date.parse('2012-12-25')], BusinessTime::Config.holidays[:common]
   end
 
   should "include holidays read from YAML config files" do
@@ -81,6 +81,31 @@ class TestConfig < Test::Unit::TestCase
     assert !Time.workday?(Time.parse('2012-05-07'))
   end
 
+  should "include holidays specified by a given type" do
+    yaml = <<-YAML
+    business_time:
+      holidays:
+        common:
+          - May 7th, 2012
+          - July 21st, 2012
+        CA:
+          - August 1st, 2012
+    YAML
+    assert Time.workday?(Time.parse('2012-08-01'))
+    assert Time.workday?(Time.parse('2012-08-01'), "CA")
+    assert Time.workday?(Time.parse('2012-08-01'), "US")
+    config_file = StringIO.new(yaml.gsub!(/^    /, ''))
+    BusinessTime::Config.load(config_file)
+    assert Time.workday?(Time.parse('2012-08-01'))
+    assert !Time.workday?(Time.parse('2012-08-01'), "CA")
+    assert Time.workday?(Time.parse('2012-08-01'), "US")
+
+    # but common holidays apply everywhere
+    assert !Time.workday?(Time.parse('2012-05-07'))
+    assert !Time.workday?(Time.parse('2012-05-07'), "US")
+    assert !Time.workday?(Time.parse('2012-05-07'), "CA")
+  end
+
   should "use defaults for values missing in YAML file" do
     yaml = <<-YAML
     business_time:
@@ -91,7 +116,7 @@ class TestConfig < Test::Unit::TestCase
     assert_equal "9:00 am", BusinessTime::Config.beginning_of_workday
     assert_equal "5:00 pm", BusinessTime::Config.end_of_workday
     assert_equal %w[mon tue wed thu fri], BusinessTime::Config.work_week
-    assert_equal [], BusinessTime::Config.holidays
+    assert_equal [], BusinessTime::Config.holidays[:common]
   end
 
 end


### PR DESCRIPTION
Holidays can sometimes be specific to a region. A holiday in one country may not be a holiday in some other country. This change allows us to specify holidays by a type.

Features
- The type of holiday is 'common' by default. Holidays that are common apply to everything
- The clients can then provide holidays with more specific types.
- The change is backwards compatible.
