### PR TITLE
Removed to_s, which can depend on user modifying the default format. Replaced with strftime for exact format.

### DIFF
--- a/lib/business_time/business_days.rb
+++ b/lib/business_time/business_days.rb
@@ -8,7 +8,7 @@ module BusinessTime
     end
 
     def after(time = Time.now)
-      time = Time.zone ? Time.zone.parse(time.rfc822) : Time.parse(time.rfc822)
+      time = Time.zone ? Time.zone.parse(time.strftime('%Y-%m-%d %H:%M:%S %z')) : Time.parse(time.strftime('%Y-%m-%d %H:%M:%S %z'))
       days = @days
       while days > 0 || !Time.workday?(time)
         days -= 1 if Time.workday?(time)


### PR DESCRIPTION
A cleaver user on my system changed the default date format, which created all sorts of bad parsing problems.  A 2 digit year, yielding a millenium bug!!! 13 years after the fact...

formats = {
  default: "%b-%d-%y %I:%M %p"
}
Time::DATE_FORMATS.merge!(formats)

Time.parse, converts the %y to 0013... which was quite a surpize.

The new code uses strftime to specify the exact format to be parsed, instead of choosing a default (which can be reset by the user)

All tests pass.

Thank you!
