### PR TITLE
business_time_until defaulting to BusinessTime::Config.end_of_workday if no param is given

### DIFF
--- a/lib/business_time/core_ext/time.rb
+++ b/lib/business_time/core_ext/time.rb
@@ -93,7 +93,9 @@ end
 
 class Time
 
-  def business_time_until(to_time)
+  def business_time_until(to_time=nil)
+
+    to_time = Time.parse(self.strftime('%Y-%m-%d ') + BusinessTime::Config.end_of_workday) if to_time.nil?
 
     # Make sure that we will calculate time from A to B "clockwise"
     direction = 1

--- a/test/test_calculating_business_duration.rb
+++ b/test/test_calculating_business_duration.rb
@@ -42,6 +42,14 @@ class TestCalculatingBusinessDuration < Test::Unit::TestCase
     assert_equal 9.hours, friday.business_time_until(monday)
   end
 
+  should "properly calculate business time with respect to work_hours when no param is given" do
+    friday = Time.parse("December 24, 2010 15:00")
+    BusinessTime::Config.work_hours = {
+      :fri=>["9:00","17:00"]
+    }
+    assert_equal 2.hours, friday.business_time_until
+  end  
+
   should "properly calculate business time with respect to work_hours with UTC time zone" do
     Time.zone = 'UTC'
 


### PR DESCRIPTION
I think this is handy for someone who just want to get the remaining working time for the day
