### PR TITLE
Loosen tzinfo dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     business_time (0.6.2)
       activesupport (>= 3.1.0)
-      tzinfo (~> 0.3.31)
+      tzinfo (>= 0.3.31)
 
 GEM
   remote: https://rubygems.org/
@@ -11,6 +11,7 @@ GEM
     activesupport (3.2.13)
       i18n (= 0.6.1)
       multi_json (~> 1.0)
+    atomic (1.1.14)
     bourne (1.4.0)
       mocha (~> 0.13.2)
     i18n (0.6.1)
@@ -29,7 +30,10 @@ GEM
     shoulda-matchers (1.5.4)
       activesupport (>= 3.0.0)
       bourne (~> 1.3)
-    tzinfo (0.3.37)
+    thread_safe (0.1.3)
+      atomic
+    tzinfo (1.1.0)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby

--- a/business_time.gemspec
+++ b/business_time.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files -- {lib,rails_generators,LICENSE,README.rdoc}`.split("\n")
 
   s.add_dependency('activesupport','>= 3.1.0')
-  s.add_dependency("tzinfo", "~> 0.3.31")
+  s.add_dependency("tzinfo", ">= 0.3.31")
 
   s.add_development_dependency "rake", ">= 0.9.2"
   s.add_development_dependency "shoulda", ">= 0"


### PR DESCRIPTION
Rails 4.1 requires tzinfo version to be at least 1.1.0. This gem is compatible with 1.x branch of tzinfo so we can loosen the dependency.
