### PR TITLE
update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 1.9.2
   - 1.9.3
   - 2.0.0
-  - jruby-19mode
+  - 2.1.0
+  - jruby


### PR DESCRIPTION
1.9.2 is basically dead and 2.1 is out :)
also all jruby is 1.9 by default

@bokmann
