### PR TITLE
make config not use self / add privacy

### DIFF
--- a/lib/business_time/config.rb
+++ b/lib/business_time/config.rb
@@ -31,91 +31,91 @@ module BusinessTime
       # someplace in the initializers of your application.
       attr_accessor :holidays
 
-      # working hours for each day - if not set using global variables :beginning_of_workday 
+      # working hours for each day - if not set using global variables :beginning_of_workday
       # and end_of_workday. Keys will be added ad weekdays.
       # Example:
       #    {:mon => ["9:00","17:00"],:tue => ["9:00","17:00"].....}
       attr_accessor :work_hours
 
-    end
+      def end_of_workday(day=nil)
+        if day
+          wday = @work_hours[int_to_wday(day.wday)]
+          wday ? (wday.last =~ /0{1,2}\:0{1,2}/ ? "23:59:59" : wday.last) : @end_of_workday
+        else
+          @end_of_workday
+        end
+      end
 
-    def self.end_of_workday(day=nil)
-      if day
-        wday = @work_hours[self.int_to_wday(day.wday)]
-        wday ? (wday.last =~ /0{1,2}\:0{1,2}/ ? "23:59:59" : wday.last) : @end_of_workday
-      else
-        @end_of_workday
+      def beginning_of_workday(day=nil)
+        if day
+          wday = @work_hours[int_to_wday(day.wday)]
+          wday ? wday.first : @beginning_of_workday
+        else
+          @beginning_of_workday
+        end
+      end
+
+      def work_week=(days)
+        @work_week = days
+        @weekdays = nil
+      end
+
+      def weekdays
+        return @weekdays unless @weekdays.nil?
+
+        @weekdays = (!work_hours.empty? ? work_hours.keys : work_week).each_with_object([]) do |day_name, days|
+          day_num = wday_to_int(day_name)
+          days << day_num unless day_num.nil?
+        end
+      end
+
+      # loads the config data from a yaml file written as:
+      #
+      #   business_time:
+      #     beginning_od_workday: 8:30 am
+      #     end_of_workday: 5:30 pm
+      #     holidays:
+      #       - Jan 1st, 2010
+      #       - July 4th, 2010
+      #       - Dec 25th, 2010
+      def load(file)
+        reset
+        data = YAML::load(file.respond_to?(:read) ? file : File.open(file))
+        config = (data["business_time"] || {})
+
+        # load each config variable from the file, if it's present and valid
+        config_vars = %w(beginning_of_workday end_of_workday work_week work_hours)
+        config_vars.each do |var|
+          send("#{var}=", config[var]) if config[var] && respond_to?("#{var}=")
+        end
+
+        (config["holidays"] || []).each do |holiday|
+          holidays << Date.parse(holiday)
+        end
+      end
+
+      private
+
+      def wday_to_int day_name
+        lowercase_day_names = ::Time::RFC2822_DAY_NAME.map(&:downcase)
+        lowercase_day_names.find_index(day_name.to_s.downcase)
+      end
+
+      def int_to_wday num
+        ::Time::RFC2822_DAY_NAME.map(&:downcase).map(&:to_sym)[num]
+      end
+
+      def reset
+        self.holidays = []
+        self.beginning_of_workday = "9:00 am"
+        self.end_of_workday = "5:00 pm"
+        self.work_week = %w[mon tue wed thu fri]
+        self.work_hours = {}
+        @weekdays = nil
       end
     end
 
-    def self.beginning_of_workday(day=nil)
-      if day
-        wday = @work_hours[self.int_to_wday(day.wday)]
-        wday ? wday.first : @beginning_of_workday
-      else
-        @beginning_of_workday
-      end
-    end
-
-    def self.work_week=(days)
-      @work_week = days
-      @weekdays = nil
-    end
-
-    def self.weekdays
-      return @weekdays unless @weekdays.nil?
-
-      @weekdays = (!work_hours.empty? ? work_hours.keys : work_week).each_with_object([]) do |day_name, days|
-        day_num = self.wday_to_int(day_name)
-        days << day_num unless day_num.nil?
-      end
-    end
-
-    def self.wday_to_int day_name
-      lowercase_day_names = ::Time::RFC2822_DAY_NAME.map(&:downcase)
-      lowercase_day_names.find_index(day_name.to_s.downcase)
-    end
-
-    def self.int_to_wday num
-      ::Time::RFC2822_DAY_NAME.map(&:downcase).map(&:to_sym)[num]
-    end
-
-    def self.reset
-      self.holidays = []
-      self.beginning_of_workday = "9:00 am"
-      self.end_of_workday = "5:00 pm"
-      self.work_week = %w[mon tue wed thu fri]
-      self.work_hours = {}
-      @weekdays = nil
-    end
-
-    # loads the config data from a yaml file written as:
-    #
-    #   business_time:
-    #     beginning_od_workday: 8:30 am
-    #     end_of_workday: 5:30 pm
-    #     holidays:
-    #       - Jan 1st, 2010
-    #       - July 4th, 2010
-    #       - Dec 25th, 2010
-    def self.load(file)
-      self.reset
-      data = YAML::load(file.respond_to?(:read) ? file : File.open(file))
-      config = (data["business_time"] || {})
-
-      # load each config variable from the file, if it's present and valid
-      config_vars = %w(beginning_of_workday end_of_workday work_week work_hours)
-      config_vars.each do |var|
-        send("#{var}=", config[var]) if config[var] && respond_to?("#{var}=")
-      end
-
-      (config["holidays"] || []).each do |holiday|
-        self.holidays << Date.parse(holiday)
-      end
-    end
-
-    #reset the first time we are loaded.
-    self.reset
+    # reset the first time we are loaded.
+    reset
   end
-
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -19,6 +19,6 @@ require 'business_time'
 
 class Test::Unit::TestCase
   def teardown
-    BusinessTime::Config.reset
+    BusinessTime::Config.send(:reset)
   end
 end

--- a/test/test_business_days.rb
+++ b/test/test_business_days.rb
@@ -1,7 +1,7 @@
 require 'helper'
 
 class TestBusinessDays < Test::Unit::TestCase
-  
+
   context "with a standard Time object" do
 
     should "move to tomorrow if we add a business day" do
@@ -10,42 +10,42 @@ class TestBusinessDays < Test::Unit::TestCase
       expected = Time.parse("April 14th, 2010, 11:00 am")
       assert_equal expected, later
     end
-  
+
     should "move to yesterday is we subtract a business day" do
       first = Time.parse("April 13th, 2010, 11:00 am")
       before = 1.business_day.before(first)
       expected = Time.parse("April 12th, 2010, 11:00 am")
       assert_equal expected, before
     end
-  
+
     should "take into account the weekend when adding a day" do
       first = Time.parse("April 9th, 2010, 12:33 pm")
       after = 1.business_day.after(first)
       expected = Time.parse("April 12th, 2010, 12:33 pm")
       assert_equal expected, after
     end
-  
+
     should "take into account the weekend when subtracting a day" do
       first = Time.parse("April 12th, 2010, 12:33 pm")
       before = 1.business_day.before(first)
       expected = Time.parse("April 9th, 2010, 12:33 pm")
       assert_equal expected, before
     end
-  
+
     should "move forward one week when adding 5 business days" do
       first = Time.parse("April 9th, 2010, 12:33 pm")
       after = 5.business_days.after(first)
       expected = Time.parse("April 16th, 2010, 12:33 pm")
       assert_equal expected, after
     end
-  
+
     should "move backward one week when subtracting 5 business days" do
       first = Time.parse("April 16th, 2010, 12:33 pm")
       before = 5.business_days.before(first)
       expected = Time.parse("April 9th, 2010, 12:33 pm")
       assert_equal expected, before
     end
-  
+
     should "take into account a holiday when adding a day" do
       three_day_weekend = Date.parse("July 5th, 2010")
       BusinessTime::Config.holidays << three_day_weekend
@@ -54,9 +54,8 @@ class TestBusinessDays < Test::Unit::TestCase
       expected = Time.parse("July 6th, 2010, 4:50 pm")
       assert_equal expected, tuesday_afternoon
     end
-  
+
     should "take into account a holiday on a weekend" do
-      BusinessTime::Config.reset
       july_4 = Date.parse("July 4th, 2010")
       BusinessTime::Config.holidays << july_4
       friday_afternoon = Time.parse("July 2nd, 2010, 4:50 pm")
@@ -80,5 +79,5 @@ class TestBusinessDays < Test::Unit::TestCase
     end
 
   end
-  
+
 end

--- a/test/test_business_days_eastern.rb
+++ b/test/test_business_days_eastern.rb
@@ -1,7 +1,7 @@
 require 'helper'
 
 class TestBusinessDays < Test::Unit::TestCase
-  
+
   context "with a TimeWithZone object set to the Eastern timezone" do
     setup do
       Time.zone = 'Eastern Time (US & Canada)'
@@ -9,7 +9,7 @@ class TestBusinessDays < Test::Unit::TestCase
     teardown do
       Time.zone = nil
     end
-    
+
     should "move to tomorrow if we add a business day" do
       first = Time.zone.parse("April 13th, 2010, 11:00 am")
       later = 1.business_day.after(first)
@@ -62,7 +62,6 @@ class TestBusinessDays < Test::Unit::TestCase
     end
 
     should "take into account a holiday on a weekend" do
-      BusinessTime::Config.reset
       july_4 = Date.parse("July 4th, 2010")
       BusinessTime::Config.holidays << july_4
       friday_afternoon = Time.zone.parse("July 2nd, 2010, 4:50 pm")
@@ -71,5 +70,5 @@ class TestBusinessDays < Test::Unit::TestCase
       assert_equal expected, monday_afternoon
     end
   end
-  
+
 end

--- a/test/test_business_days_utc.rb
+++ b/test/test_business_days_utc.rb
@@ -1,7 +1,7 @@
 require 'helper'
 
 class TestBusinessDays < Test::Unit::TestCase
-  
+
   context "with a TimeWithZone object set to UTC" do
     setup do
       Time.zone = 'UTC'
@@ -9,7 +9,7 @@ class TestBusinessDays < Test::Unit::TestCase
     teardown do
       Time.zone = nil
     end
-    
+
     should "move to tomorrow if we add a business day" do
       first = Time.zone.parse("April 13th, 2010, 11:00 am")
       later = 1.business_day.after(first)
@@ -62,7 +62,6 @@ class TestBusinessDays < Test::Unit::TestCase
     end
 
     should "take into account a holiday on a weekend" do
-      BusinessTime::Config.reset
       july_4 = Date.parse("July 4th, 2010")
       BusinessTime::Config.holidays << july_4
       friday_afternoon = Time.zone.parse("July 2nd, 2010, 4:50 pm")

--- a/test/test_time_extensions.rb
+++ b/test/test_time_extensions.rb
@@ -18,8 +18,6 @@ class TestTimeExtensions < Test::Unit::TestCase
   end
 
   should "know a holiday is not a workday" do
-    BusinessTime::Config.reset
-
     BusinessTime::Config.holidays << Date.parse("July 4, 2010")
     BusinessTime::Config.holidays << Date.parse("July 5, 2010")
 

--- a/test/test_time_with_zone_extensions.rb
+++ b/test/test_time_with_zone_extensions.rb
@@ -1,92 +1,88 @@
 require 'helper'
 
 class TestTimeWithZoneExtensions < Test::Unit::TestCase
-  
+
   context "With Eastern Standard Time" do
     setup do
       Time.zone = 'Eastern Time (US & Canada)'
     end
-    
+
     should "know what a weekend day is" do
       assert( Time.weekday?(Time.zone.parse("April 9, 2010 10:30am")))
       assert(!Time.weekday?(Time.zone.parse("April 10, 2010 10:30am")))
       assert(!Time.weekday?(Time.zone.parse("April 11, 2010 10:30am")))
       assert( Time.weekday?(Time.zone.parse("April 12, 2010 10:30am")))
     end
-  
+
     should "know a weekend day is not a workday" do
       assert( Time.workday?(Time.zone.parse("April 9, 2010 10:45 am")))
       assert(!Time.workday?(Time.zone.parse("April 10, 2010 10:45 am")))
       assert(!Time.workday?(Time.zone.parse("April 11, 2010 10:45 am")))
       assert( Time.workday?(Time.zone.parse("April 12, 2010 10:45 am")))
     end
-  
+
     should "know a holiday is not a workday" do
-      BusinessTime::Config.reset
-    
       BusinessTime::Config.holidays << Date.parse("July 4, 2010")
       BusinessTime::Config.holidays << Date.parse("July 5, 2010")
-    
+
       assert(!Time.workday?(Time.zone.parse("July 4th, 2010 1:15 pm")))
       assert(!Time.workday?(Time.zone.parse("July 5th, 2010 2:37 pm")))
     end
-  
-  
+
+
     should "know the beginning of the day for an instance" do
       first = Time.zone.parse("August 17th, 2010, 11:50 am")
       expecting = Time.zone.parse("August 17th, 2010, 9:00 am")
       assert_equal expecting, Time.beginning_of_workday(first)
     end
-  
+
     should "know the end of the day for an instance" do
       first = Time.zone.parse("August 17th, 2010, 11:50 am")
       expecting = Time.zone.parse("August 17th, 2010, 5:00 pm")
       assert_equal expecting, Time.end_of_workday(first)
     end
   end
-  
-  
+
+
   context "With UTC Timezone" do
     setup do
       Time.zone = 'UTC'
     end
-    
+
     should "know what a weekend day is" do
       assert( Time.weekday?(Time.zone.parse("April 9, 2010 10:30am")))
       assert(!Time.weekday?(Time.zone.parse("April 10, 2010 10:30am")))
       assert(!Time.weekday?(Time.zone.parse("April 11, 2010 10:30am")))
       assert( Time.weekday?(Time.zone.parse("April 12, 2010 10:30am")))
     end
-  
+
     should "know a weekend day is not a workday" do
       assert( Time.workday?(Time.zone.parse("April 9, 2010 10:45 am")))
       assert(!Time.workday?(Time.zone.parse("April 10, 2010 10:45 am")))
       assert(!Time.workday?(Time.zone.parse("April 11, 2010 10:45 am")))
       assert( Time.workday?(Time.zone.parse("April 12, 2010 10:45 am")))
     end
-  
+
     should "know a holiday is not a workday" do
-      BusinessTime::Config.reset
-    
       BusinessTime::Config.holidays << Date.parse("July 4, 2010")
       BusinessTime::Config.holidays << Date.parse("July 5, 2010")
-    
+
       assert(!Time.workday?(Time.zone.parse("July 4th, 2010 1:15 pm")))
       assert(!Time.workday?(Time.zone.parse("July 5th, 2010 2:37 pm")))
     end
-  
-  
+
+
     should "know the beginning of the day for an instance" do
       first = Time.zone.parse("August 17th, 2010, 11:50 am")
       expecting = Time.zone.parse("August 17th, 2010, 9:00 am")
       assert_equal expecting, Time.beginning_of_workday(first)
     end
-  
+
     should "know the end of the day for an instance" do
       first = Time.zone.parse("August 17th, 2010, 11:50 am")
       expecting = Time.zone.parse("August 17th, 2010, 5:00 pm")
       assert_equal expecting, Time.end_of_workday(first)
     end
   end
-  
+
 end


### PR DESCRIPTION
@bokmann best viewed [without whitespace changes](https://github.com/bokmann/business_time/pull/62/files?w=1)

removed the redundant resets since it's already done in each teardown
