### PR TITLE
make config threadsafe and changeable via with block

### DIFF
--- a/lib/business_time/config.rb
+++ b/lib/business_time/config.rb
@@ -7,8 +7,14 @@ module BusinessTime
   # manually, or with a yaml file and the load method.
   class Config
     class << self
+      private
+
       def config
         Thread.current[:business_time_config] ||= {}
+      end
+
+      def config=(config)
+        Thread.current[:business_time_config] = config
       end
 
       def threadsafe_cattr_accessor(name)
@@ -109,6 +115,14 @@ module BusinessTime
         (config["holidays"] || []).each do |holiday|
           holidays << Date.parse(holiday)
         end
+      end
+
+      def with(config)
+        old = config().dup
+        config.each { |k,v| send("#{k}=", v) } # calculations are done on setting
+        yield
+      ensure
+        self.config = old
       end
 
       private


### PR DESCRIPTION
@bokmann includes all my unmerged PR's + threadsafe config + changable config via with block

``` Ruby
BusinessTime::Config.with(:end_of_workday => "2pm") do
  BusinessTime::Config.with(:beginning_of_workday => "1pm") do
     ... do some calculations ...
  end
end
```

/cc @morten @aghassipour 
