### PR TITLE
Fix configuration sharing between threads

### DIFF
--- a/lib/business_time/config.rb
+++ b/lib/business_time/config.rb
@@ -20,11 +20,11 @@ module BusinessTime
       private
 
       def config
-        Thread.current[:business_time_config] ||= default_config
+        Thread.main[:business_time_config] ||= default_config
       end
 
       def config=(config)
-        Thread.current[:business_time_config] = config
+        Thread.main[:business_time_config] = config
       end
 
       def threadsafe_cattr_accessor(name)


### PR DESCRIPTION
On rubinius, global configuration wasn’t working, each thread having
its own. By using `Thread.main` instead of `Thread.current` it should
now be fixed.
