### PR TITLE
Add a new method to Time

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -89,7 +89,7 @@ I needed this, but taking into account business hours/days and holidays.
     ticket_reported = Time.parse("February 3, 2012, 10:40 am")
     ticket_resolved = Time.parse("February 4, 2012, 10:50 am")
     ticket_reported.business_time_until(ticket_resolved) #=> 8.hours + 10.minutes
-    
+
     # you can also determine if a given time is within business hours
     Time.parse("February 3, 2012, 10:00 am").during_business_hours?
 
@@ -107,6 +107,12 @@ I needed this, but taking into account business hours/days and holidays.
     monday = Date.parse("December 20, 2010")
     wednesday = Date.parse("December 22, 2010")
     monday.business_dates_until(wednesday) #=> [Mon, 20 Dec 2010, Tue, 21 Dec 2010]
+
+    # you can get the first workday after a time or return itself if it is a workday
+    saturday = Time.parse("Sat Aug 9, 18:00:00, 2014")
+    monday = Time.parse("Mon Aug 11, 18:00:00, 2014")
+    Time.first_business_day(saturday) #=> "Mon Aug 11, 18:00:00, 2014"
+    Time.first_business_day(monday) #=> "Mon Aug 11, 18:00:00, 2014"
 == Rails generator
 
     rails generate business_time:config

--- a/lib/business_time/time_extensions.rb
+++ b/lib/business_time/time_extensions.rb
@@ -62,6 +62,16 @@ module BusinessTime
         next_business_time
       end
 
+      # Returns the time parameter itself if it is a business day
+      # or else returns the next business day
+      def first_business_day(time)
+        while !Time.workday?(time)
+          time = time + 1.day
+        end
+
+        time
+      end
+
       # Rolls backwards to the previous end_of_workday when the time is outside
       # of business hours
       def roll_backward(time)

--- a/test/test_business_hours.rb
+++ b/test/test_business_hours.rb
@@ -64,6 +64,17 @@ describe "business hours" do
       assert_equal tuesday_morning, Time.roll_forward(monday_evening)
     end
 
+    it "get the first business after the time that is not a business hour" do
+      saturday = Time.parse("Sat Aug 9, 18:00:00, 2014")
+      monday = Time.parse("Mon Aug 11, 18:00:00, 2014")
+      assert_equal monday, Time.first_business_day(saturday)
+    end
+
+    it "get the time itself if it is a business hour" do
+      monday = Time.parse("Mon Aug 11, 18:00:00, 2014")
+      assert_equal monday, Time.first_business_day(monday)
+    end
+
     it "consider any time on a weekend as equivalent to monday morning" do
       sunday = Time.parse("Sun Apr 25 12:06:56, 2010")
       monday = Time.parse("Mon Apr 26, 09:00:00, 2010")


### PR DESCRIPTION
Hey guys,

I added the method `first_business_day` in a application that I work and I think that it could be pretty useful for other people.
This method returns the time of the next business day or itself if it is a business date already.
The difference between `first_business_day` and `roll_forward` is that the new method cares about only with the day and not with the time.

I don't know if I picked the best method name.

Well, let me know if I can improve anything. Best regards.