### PR TITLE
BusinessTime::Config.time_zone

### DIFF
--- a/lib/business_time/business_days.rb
+++ b/lib/business_time/business_days.rb
@@ -8,7 +8,7 @@ module BusinessTime
     end
 
     def after(time = Time.now)
-      time = Time.zone ? Time.zone.parse(time.strftime('%Y-%m-%d %H:%M:%S %z')) : Time.parse(time.strftime('%Y-%m-%d %H:%M:%S %z'))
+      time = BusinessTime::Config.time_zone ? BusinessTime::Config.time_zone.parse(time.strftime('%Y-%m-%d %H:%M:%S %z')) : Time.parse(time.strftime('%Y-%m-%d %H:%M:%S %z'))
       days = @days
       while days > 0 || !Time.workday?(time)
         days -= 1 if Time.workday?(time)
@@ -21,7 +21,7 @@ module BusinessTime
     alias_method :since, :after
     
     def before(time = Time.now)
-      time = Time.zone ? Time.zone.parse(time.rfc822) : Time.parse(time.rfc822)
+      time = BusinessTime::Config.time_zone ? BusinessTime::Config.time_zone.parse(time.rfc822) : Time.parse(time.rfc822)
       days = @days
       while days > 0 || !Time.workday?(time)
         days -= 1 if Time.workday?(time)

--- a/lib/business_time/business_days.rb
+++ b/lib/business_time/business_days.rb
@@ -7,7 +7,11 @@ module BusinessTime
       @days = days
     end
 
-    def after(time = Time.now)
+    def now
+      BusinessTime::Config.time_zone ? BusinessTime::Config.time_zone.now : Time.now
+    end
+
+    def after(time = now)
       time = BusinessTime::Config.time_zone ? BusinessTime::Config.time_zone.parse(time.strftime('%Y-%m-%d %H:%M:%S %z')) : Time.parse(time.strftime('%Y-%m-%d %H:%M:%S %z'))
       days = @days
       while days > 0 || !Time.workday?(time)
@@ -20,7 +24,7 @@ module BusinessTime
     alias_method :from_now, :after
     alias_method :since, :after
     
-    def before(time = Time.now)
+    def before(time = now)
       time = BusinessTime::Config.time_zone ? BusinessTime::Config.time_zone.parse(time.rfc822) : Time.parse(time.rfc822)
       days = @days
       while days > 0 || !Time.workday?(time)

--- a/lib/business_time/business_hours.rb
+++ b/lib/business_time/business_hours.rb
@@ -6,11 +6,11 @@ module BusinessTime
     end
 
     def ago
-      Time.zone ? before(Time.zone.now) : before(Time.now)
+      BusinessTime::Config.time_zone ? before(BusinessTime::Config.time_zone.now) : before(Time.now)
     end
 
     def from_now
-      Time.zone ?  after(Time.zone.now) : after(Time.now)
+      BusinessTime::Config.time_zone ?  after(BusinessTime::Config.time_zone.now) : after(Time.now)
     end
 
     def after(time)

--- a/lib/business_time/config.rb
+++ b/lib/business_time/config.rb
@@ -7,6 +7,7 @@ module BusinessTime
   # manually, or with a yaml file and the load method.
   class Config
     DEFAULT_CONFIG = {
+      time_zone:             nil,
       holidays:              [],
       beginning_of_workday:  '9:00 am',
       end_of_workday:        '5:00 pm',
@@ -36,6 +37,12 @@ module BusinessTime
         end
       end
     end
+
+    # You can set this yourself, either by the load method below, or
+    # by saying
+    #   BusinessTime::Config.time_zone = "UTC"
+    # someplace in the initializers of your application.
+    threadsafe_cattr_accessor :time_zone
 
     # You can set this yourself, either by the load method below, or
     # by saying
@@ -73,6 +80,14 @@ module BusinessTime
     threadsafe_cattr_accessor :_weekdays # internal
 
     class << self
+      def time_zone
+        config[:time_zone] || Time.zone
+      end
+
+      def time_zone=(zone)
+        config[:time_zone] = Time.find_zone!(zone)
+      end
+
       def end_of_workday(day=nil)
         if day
           wday = work_hours[int_to_wday(day.wday)]

--- a/lib/business_time/config.rb
+++ b/lib/business_time/config.rb
@@ -135,7 +135,7 @@ module BusinessTime
         config = (data["business_time"] || {})
 
         # load each config variable from the file, if it's present and valid
-        config_vars = %w(beginning_of_workday end_of_workday work_week work_hours)
+        config_vars = %w(time_zone beginning_of_workday end_of_workday work_week work_hours)
         config_vars.each do |var|
           send("#{var}=", config[var]) if config[var] && respond_to?("#{var}=")
         end

--- a/lib/business_time/time_extensions.rb
+++ b/lib/business_time/time_extensions.rb
@@ -104,8 +104,8 @@ module BusinessTime
       private
 
       def change_business_time time, hour, min=0, sec=0
-        if Time.zone
-          time.in_time_zone(Time.zone).change(:hour => hour, :min => min, :sec => sec)
+        if BusinessTime::Config.time_zone
+          time.in_time_zone(BusinessTime::Config.time_zone).change(:hour => hour, :min => min, :sec => sec)
         else
           time.change(:hour => hour, :min => min, :sec => sec)
         end

--- a/test/test_business_hours_time_zone_config.rb
+++ b/test/test_business_hours_time_zone_config.rb
@@ -1,0 +1,26 @@
+require File.expand_path('../helper', __FILE__)
+
+describe "business hours" do
+  describe "with BusinessTime::Config.time_zone set to Eastern and Time.zone set to UTC" do
+    before do
+      BusinessTime::Config.time_zone = 'Eastern Time (US & Canada)'
+      Time.zone = 'UTC'
+    end
+
+    it "uses BusinessTime::Config.time_zone" do
+      first = BusinessTime::Config.time_zone.parse("February 3rd, 2014, 3:30 pm")
+      later = 1.business_hour.after(first)
+      expected = BusinessTime::Config.time_zone.parse("February 3rd, 2014, 4:30 pm")
+      assert_equal expected, later
+    end
+
+    it "converts Time.zone into BusinessTime::Config.time_zone" do
+      # EST = UTC-5
+      # UTC = EST+5
+      first = Time.zone.parse("February 3rd, 2014, 8:30 pm")
+      later = 1.business_hour.after(first)
+      expected = Time.zone.parse("February 3rd, 2014, 9:30 pm")
+      assert_equal expected, later
+    end
+  end
+end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -75,6 +75,7 @@ describe "config" do
   it "load config from YAML files" do
     yaml = <<-YAML
     business_time:
+      time_zone: UTC
       beginning_of_workday: 11:00 am
       end_of_workday: 2:00 pm
       work_week:
@@ -84,6 +85,7 @@ describe "config" do
     YAML
     config_file = StringIO.new(yaml.gsub!(/^    /, ''))
     BusinessTime::Config.load(config_file)
+    assert_equal "UTC", BusinessTime::Config.time_zone.name
     assert_equal "11:00 am", BusinessTime::Config.beginning_of_workday
     assert_equal "2:00 pm", BusinessTime::Config.end_of_workday
     assert_equal ['mon'], BusinessTime::Config.work_week

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -1,6 +1,16 @@
 require File.expand_path('../helper', __FILE__)
 
 describe "config" do
+  it "uses Time.zone when time zone is not set" do
+    Time.zone = "Darwin"
+    assert_equal "Darwin", BusinessTime::Config.time_zone.name
+  end
+
+  it "keep track of time zone" do
+    BusinessTime::Config.time_zone = "Ljubljana"
+    assert_equal "Ljubljana", BusinessTime::Config.time_zone.name
+  end
+
   it "keep track of the start of the day" do
     assert_equal "9:00 am", BusinessTime::Config.beginning_of_workday
     BusinessTime::Config.beginning_of_workday = "8:30 am"


### PR DESCRIPTION
This separates BusinessTime time zone from the global Time.zone configuration.  By default, it still pulls directly off Time.zone, but it can be changed separately.
