### PR TITLE
Remove the deprecation warning from #first_business_day

### DIFF
--- a/lib/business_time/time_extensions.rb
+++ b/lib/business_time/time_extensions.rb
@@ -73,7 +73,7 @@ module BusinessTime
       # Returns the time parameter itself if it is a business day
       # or else returns the next business day
       def first_business_day(time)
-        while !Time.workday?(time)
+        while !Time.workday?(time) || !time.workday?
           time = time + 1.day
         end
 

--- a/lib/business_time/time_extensions.rb
+++ b/lib/business_time/time_extensions.rb
@@ -73,7 +73,7 @@ module BusinessTime
       # Returns the time parameter itself if it is a business day
       # or else returns the next business day
       def first_business_day(time)
-        while !Time.workday?(time) || !time.workday?
+        while !time.workday?
           time = time + 1.day
         end
 


### PR DESCRIPTION
The existing code for #first_business_day throws a deprecation warning because of it's use of Time.weekday?