### PR TITLE
Fixes for issues #36, #45 and #83 (bug in business_days.before/after)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 rvm:
   - 1.9.3
   - 2.0.0

--- a/lib/business_time/business_days.rb
+++ b/lib/business_time/business_days.rb
@@ -4,7 +4,7 @@ module BusinessTime
   class BusinessDays
     include Comparable
     attr_reader :days
-    
+
     def initialize(days)
       @days = days
     end
@@ -15,12 +15,17 @@ module BusinessTime
       end
       self.days <=> other.days
     end
-    
+
     def after(time = Time.current)
       days = @days
       while days > 0 || !time.workday?
         days -= 1 if time.workday?
         time = time + 1.day
+      end
+      # If we have a Time or DateTime object, we can roll_forward to the
+      #   beginning of the next business day
+      if time.is_a?(Time) || time.is_a?(DateTime)
+        time = Time.roll_forward(time) unless time.during_business_hours?
       end
       time
     end
@@ -34,9 +39,16 @@ module BusinessTime
         days -= 1 if time.workday?
         time = time - 1.day
       end
+      # If we have a Time or DateTime object, we can roll_backward to the
+      #   beginning of the previous business day
+      if time.is_a?(Time) || time.is_a?(DateTime)
+        unless time.during_business_hours?
+          time = Time.beginning_of_workday(Time.roll_backward(time))
+        end
+      end
       time
     end
-    
+
     alias_method :ago, :before
     alias_method :until, :before
   end

--- a/lib/business_time/business_days.rb
+++ b/lib/business_time/business_days.rb
@@ -11,7 +11,7 @@ module BusinessTime
 
     def <=>(other)
       if other.class != self.class
-        raise ArgumentError.new("#{self.class.to_s} can't be compared with #{other.class.to_s}")
+        raise ArgumentError.new("#{self.class} can't be compared with #{other.class}")
       end
       self.days <=> other.days
     end
@@ -20,7 +20,7 @@ module BusinessTime
       days = @days
       while days > 0 || !time.workday?
         days -= 1 if time.workday?
-        time = time + 1.day
+        time += 1.day
       end
       # If we have a Time or DateTime object, we can roll_forward to the
       #   beginning of the next business day
@@ -37,7 +37,7 @@ module BusinessTime
       days = @days
       while days > 0 || !time.workday?
         days -= 1 if time.workday?
-        time = time - 1.day
+        time -= 1.day
       end
       # If we have a Time or DateTime object, we can roll_backward to the
       #   beginning of the previous business day

--- a/test/test_business_days.rb
+++ b/test/test_business_days.rb
@@ -75,27 +75,57 @@ describe "business days" do
       expected = Time.parse("April 8th, 2010, 11:00 am")
       assert_equal expected, before
     end
-    
+
+    it "should return a business hour when adding one business day from before business hours" do
+      wednesday = Time.parse("Wednesday October 14th, 2015, 01:54 am")
+      later = 1.business_days.after(wednesday)
+      expected = Time.parse("Thursday October 15th, 2015, 09:00 am")
+      assert_equal expected, later
+    end
+
+    it "should return a business hour when adding one business day from after business hours" do
+      wednesday = Time.parse("Wednesday October 14th, 2015, 21:54 pm")
+      later = 1.business_days.after(wednesday)
+      expected = Time.parse("Friday October 16th, 2015, 09:00 am")
+      assert_equal expected, later
+    end
+
+    it "should return a business hour when subtracting one business day from before business hours" do
+      wednesday = Time.parse("Wednesday October 14th, 2015, 01:54 am")
+      before = 1.business_days.before(wednesday)
+      expected = Time.parse("Monday October 12th, 2015, 09:00 am")
+      assert before.during_business_hours?
+      assert_equal expected, before
+    end
+
+    it "should return a business hour when subtracting one business day from after business hours" do
+      wednesday = Time.parse("Wednesday October 14th, 2015, 21:54 pm")
+      before = 1.business_days.before(wednesday)
+      expected = Time.parse("Tuesday October 13th, 2015, 09:00 am")
+      assert before.during_business_hours?
+      assert_equal expected, before
+    end
+
     it "responds appropriatly to <" do
       assert 5.business_days < 10.business_days
       assert !(10.business_days < 5.business_days)
     end
-    
+
     it "responds appropriatly to >" do
       assert !(5.business_days > 10.business_days)
       assert 10.business_days > 5.business_days
     end
-    
+
     it "responds appropriatly to ==" do
       assert 5.business_days == 5.business_days
       assert 10.business_days != 5.business_days
     end
-    
+
     it "won't compare days to hours" do
       assert_raises ArgumentError do
         5.business_days < 5.business_hours
       end
     end
-    
+
   end
 end


### PR DESCRIPTION
### Changed
- Changes in `BusinessTime.before` and `BusinessTime.after` methods to ensure that we return the time at the beginning of the business day when working with a `Time` or `DateTime` object. How the method handles `Date` objects is unaffected
- Minor refactoring suggested by Rubocop.
### New Example Output

```
irb(main):001:0> require 'business_time'
=> true
irb(main):002:0> 1.business_day.before Date.parse("Thursday October 15th, 2015")
=> Wed, 14 Oct 2015
irb(main):003:0> 1.business_day.before Time.parse("Thursday October 15th, 2015, 15:00")
=> 2015-10-14 15:00:00 +0100
irb(main):004:0> 1.business_day.before Time.parse("Thursday October 15th, 2015, 05:10")
=> 2015-10-13 09:00:00 +0100
irb(main):005:0> 1.business_day.before DateTime.parse("Thursday October 15th, 2015, 05:10")
=> Tue, 13 Oct 2015 09:00:00 +0000
```
### Test cases

Failing test cases were added before the work was completed:

```
➜  business_time git:(feature/issue-83) ✗ rake
business_time 0.7.4 built to pkg/business_time-0.7.4.gem.
business_time 0.7.4 built to pkg/business_time-0.7.4.gem.
business_time (0.7.4) installed.
/Users/jason/.rbenv/versions/2.2.3/bin/ruby -I"lib" -I"/Users/jason/.rbenv/versions/2.2.3/lib/ruby/2.2.0" "/Users/jason/.rbenv/versions/2.2.3/lib/ruby/2.2.0/rake/rake_test_loader.rb" "test/test*.rb"
Run options: --seed 45686

# Running:

............................................................................................................................F.FF........F........

Finished in 0.198888s, 729.0535 runs/s, 1096.0943 assertions/s.

  1) Failure:
business days::with a standard Time object#test_0012_should return a business hour when adding one business day from after business hours [/Users/jason/Code/business_time/test/test_business_days.rb:90]:
Expected: 2015-10-16 09:00:00 +0100
  Actual: 2015-10-15 21:54:00 +0100


  2) Failure:
business days::with a standard Time object#test_0011_should return a business hour when adding one business day from before business hours [/Users/jason/Code/business_time/test/test_business_days.rb:83]:
Expected: 2015-10-15 09:00:00 +0100
  Actual: 2015-10-15 01:54:00 +0100


  3) Failure:
business days::with a standard Time object#test_0013_should return a business hour when subtracting one business day from before business hours [/Users/jason/Code/business_time/test/test_business_days.rb:97]:
Failed assertion, no message given.


  4) Failure:
business days::with a standard Time object#test_0014_should return a business hour when subtracting one business day from after business hours [/Users/jason/Code/business_time/test/test_business_days.rb:105]:
Failed assertion, no message given.

145 runs, 218 assertions, 4 failures, 0 errors, 0 skips
```
