### PR TITLE
Adds support for inclusive results from business_days_until() method

### DIFF
--- a/lib/business_time/core_ext/date.rb
+++ b/lib/business_time/core_ext/date.rb
@@ -2,11 +2,15 @@
 class Date
   include BusinessTime::TimeExtensions
 
-  def business_days_until(to_date)
-    business_dates_until(to_date).size
+  def business_days_until(to_date, inclusive = false)
+    business_dates_until(to_date, inclusive).size
   end
 
-  def business_dates_until(to_date)
-    (self...to_date).select { |day| day.workday? }
+  def business_dates_until(to_date, inclusive = false)
+    if inclusive
+      (self..to_date).select(&:workday?)
+    else
+      (self...to_date).select(&:workday?)
+    end
   end
 end

--- a/test/test_calculating_business_duration.rb
+++ b/test/test_calculating_business_duration.rb
@@ -7,6 +7,24 @@ describe "calculating business duration" do
     assert_equal 2, monday.business_days_until(wednesday)
   end
 
+  it "can calculate exclusive business duration" do
+    monday = Date.parse("December 20, 2010")
+    wednesday = Date.parse("December 22, 2010")
+    assert_equal 2, monday.business_days_until(wednesday, false)
+  end
+
+  it "can calculate inclusive business duration" do
+    monday = Date.parse("December 20, 2010")
+    wednesday = Date.parse("December 22, 2010")
+    assert_equal 3, monday.business_days_until(wednesday, true)
+  end
+
+  it "can calculate inclusive business duration over weekends" do
+    sunday = Date.parse("November 15, 2015")
+    friday = Date.parse("November 20, 2015")
+    assert_equal 5, sunday.business_days_until(friday, true)
+  end
+
   it "properly calculate business time with respect to work_hours" do
     friday = Time.parse("December 24, 2010 15:00")
     monday = Time.parse("December 27, 2010 11:00")


### PR DESCRIPTION
## Added
- Support for an inclusive version of the `date.business_days_until(other_date)` method.

Previously, `monday.business_days_until(wednesday)` would return 2.
This change allows you to pass an 'inclusive' flag to this method; `business_days_until(date, inclusive = true)` to get the count of all the business days in this range, so calling `monday.business_days_until(wednesday, true)` will return 3.

Happy for any feedback on this; if you feel this better fits somewhere else, in another method, or isn't useful at all.
I've personally found use for this when calculating the total number of days in a range (i.e. if someone books a vacation from Monday to Wednesday, they are off for three days; Monday, Tuesday, Wednesday, back to work Thursday)
