### PR TITLE
Update bundler before travis builds 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ rvm:
   - 2.1.5
   - 2.2.0
   - jruby
+before_install:
+ - gem update bundler


### PR DESCRIPTION
Latest builds on travis are broken because of bundler is too old and contains some issues
Refs: bundler/bundler#3558 travis-ci/travis-ci#3531
