### PR TITLE
Force dateformat for regex

### DIFF
--- a/lib/business_time/business_hours.rb
+++ b/lib/business_time/business_hours.rb
@@ -60,7 +60,7 @@ module BusinessTime
 
           # Due to the 23:59:59 end-of-workday exception
           time_roll_backward = Time.roll_backward(before_time)
-          time_roll_backward += 1.second if time_roll_backward.to_s =~ /23:59:59/
+          time_roll_backward += 1.second if time_roll_backward.iso8601 =~ /23:59:59/
 
           before_time = time_roll_backward - delta
         end


### PR DESCRIPTION
It's possible for a user to have a different default date format.  In that case, the regex check may fail.  Here, instead of `to_s` we can use `iso8601` to get a known format.
