### PR TITLE
Fix timezone inconsistencies

### DIFF
--- a/lib/business_time/time_extensions.rb
+++ b/lib/business_time/time_extensions.rb
@@ -132,11 +132,7 @@ module BusinessTime
       private
 
       def change_business_time time, hour, min=0, sec=0
-        if Time.zone
-          time.in_time_zone(Time.zone).change(:hour => hour, :min => min, :sec => sec)
-        else
-          time.change(:hour => hour, :min => min, :sec => sec)
-        end
+        time.change(:hour => hour, :min => min, :sec => sec)
       end
     end
 

--- a/test/test_business_time_until_eastern.rb
+++ b/test/test_business_time_until_eastern.rb
@@ -3,13 +3,26 @@ require File.expand_path('../helper', __FILE__)
 describe "#business_time_until" do
   describe "on a TimeWithZone object in US Eastern" do
     before do
+      ENV['TZ'] = 'Pacific Time (US & Canada)'
       Time.zone = 'Eastern Time (US & Canada)'
     end
 
     it "should respect the time zone" do
+       three_o_clock = Time.zone.parse("2014-02-17 15:00:00")
+       four_o_clock = Time.zone.parse("2014-02-17 16:00:00")
+       assert_equal 60*60, three_o_clock.business_time_until(four_o_clock)
+    end
+    
+    it "should respect the time zone for TimeWithZone" do
       three_o_clock = Time.zone.parse("2014-02-17 15:00:00")
-      four_o_clock = Time.zone.parse("2014-02-17 16:00:00")
-      assert_equal 60*60, three_o_clock.business_time_until(four_o_clock)
+      nine_o_clock = Time.zone.parse("2014-02-17 09:00:00")
+      assert_equal nine_o_clock, Time.beginning_of_workday(three_o_clock)
+    end
+
+    it "should respect the time zone for Time" do
+      three_o_clock = Time.parse("2014-02-17 15:00:00")
+      nine_o_clock = Time.parse("2014-02-17 09:00:00")
+      assert_equal nine_o_clock, Time.beginning_of_workday(three_o_clock)
     end
   end
 end

--- a/test/test_calculating_business_duration.rb
+++ b/test/test_calculating_business_duration.rb
@@ -39,8 +39,8 @@ describe "calculating business duration" do
   it "properly calculate business time with respect to work_hours with UTC time zone" do
     Time.zone = 'UTC'
 
-    monday = Time.parse("May 28 11:04:26 +0300 2012")
-    tuesday = Time.parse("May 29 17:56:45 +0300 2012")
+    monday = Time.zone.parse("May 28 11:04:26 +0300 2012")
+    tuesday = Time.zone.parse("May 29 17:56:45 +0300 2012")
     BusinessTime::Config.work_hours = {
         :mon => ["9:00", "18:00"],
         :tue => ["9:00", "18:00"],


### PR DESCRIPTION
When you use Time.parse, you get a Time object back; when
you use Time.zone.parse, you get a TimeWithZone. The code
should preserve the timezone _on this time object_, not
re-apply Time.zone, which can change independently of time
objects.

Added to the misnamed business_time_until_eastern test to demonstrate
that timezone is preserved in both Time and TimeWithZone objects;
fixed a failing test in test_calculating_business_duration
that wrongly assumed that Time.parse objects should follow
Time.zone.
