### PR TITLE
require version file

### DIFF
--- a/lib/business_time.rb
+++ b/lib/business_time.rb
@@ -4,6 +4,7 @@ require 'active_support/time'
 require 'time'
 require 'yaml'
 
+require 'business_time/version'
 require 'business_time/config'
 require 'business_time/business_hours'
 require 'business_time/business_days'


### PR DESCRIPTION
I couldn't check gem version in `pry`, so it's better to require it.

```
pry> require 'business_time'
true
pry> BusinessTime::VERSION
NameError: uninitialized constant BusinessTime::VERSION
```
