### PR TITLE
Fiscal date methods

### DIFF
--- a/lib/business_time/config.rb
+++ b/lib/business_time/config.rb
@@ -14,6 +14,7 @@ module BusinessTime
       work_hours:            {},
       work_hours_total:      {},
       _weekdays:             nil,
+      fiscal_month_offset:   10,
     }
 
     class << self
@@ -85,6 +86,8 @@ module BusinessTime
     threadsafe_cattr_accessor :work_hours_total
 
     threadsafe_cattr_accessor :_weekdays # internal
+
+    threadsafe_cattr_accessor :fiscal_month_offset
 
     class << self
       def end_of_workday(day=nil)

--- a/lib/business_time/core_ext/date.rb
+++ b/lib/business_time/core_ext/date.rb
@@ -13,4 +13,49 @@ class Date
       (self...to_date).select(&:workday?)
     end
   end
+
+  # Adapted from:
+  # https://github.com/activewarehouse/activewarehouse/blob/master/lib/active_warehouse/core_ext/time/calculations.rb
+
+  def week
+    cyw = ((yday - 1) / 7) + 1
+    cyw = 52 if cyw == 53
+    cyw
+  end
+
+  def quarter
+    ((month - 1) / 3) + 1
+  end
+
+  def fiscal_month_offset
+    BusinessTime::Config.fiscal_month_offset
+  end
+
+  def fiscal_year_week
+    fyw = ((fiscal_year_yday - 1) / 7) + 1
+    fyw = 52 if fyw == 53
+    fyw
+  end
+
+  def fiscal_year_month
+    shifted_month = month - (fiscal_month_offset - 1)
+    shifted_month += 12 if shifted_month <= 0
+    shifted_month
+  end
+
+  def fiscal_year_quarter
+    ((fiscal_year_month - 1) / 3) + 1
+  end
+
+  def fiscal_year
+    month >= fiscal_month_offset ? year + 1 : year
+  end
+
+  def fiscal_year_yday
+    offset_days = 0
+    1.upto(fiscal_month_offset - 1) { |m| offset_days += ::Time.days_in_month(m, year) }
+    shifted_year_day = yday - offset_days
+    shifted_year_day += 365 if shifted_year_day <= 0
+    shifted_year_day
+  end
 end

--- a/test/test_date_extensions.rb
+++ b/test/test_date_extensions.rb
@@ -29,4 +29,61 @@ describe "date extensions" do
     assert(!july_4.workday?)
     assert(!july_5.workday?)
   end
+
+  it "#week" do
+    assert_equal  1, Date.parse("Jan 1, 2017").week
+    assert_equal  1, Date.parse("Jan 7, 2017").week
+    assert_equal  2, Date.parse("Jan 8, 2017").week
+    assert_equal 51, Date.parse("Dec 23, 2017").week
+    assert_equal 52, Date.parse("Dec 24, 2017").week
+    assert_equal 52, Date.parse("Dec 31, 2017").week # There is no 53rd week
+  end
+
+  it "#quarter" do
+    assert_equal 1, Date.parse("Jan 1, 2017").quarter
+    assert_equal 1, Date.parse("Mar 31, 2017").quarter
+    assert_equal 2, Date.parse("Apr 1, 2017").quarter
+    assert_equal 4, Date.parse("Dec 31, 2017").quarter
+  end
+
+  it "#fiscal_year_week" do
+    assert_equal 52, Date.parse("Sep 30, 2017").fiscal_year_week # There is no 53rd week
+    assert_equal  1, Date.parse("Oct 1, 2017").fiscal_year_week
+    assert_equal  5, Date.parse("Nov 1, 2017").fiscal_year_week
+    assert_equal  9, Date.parse("Dec 1, 2017").fiscal_year_week
+    assert_equal 14, Date.parse("Jan 1, 2017").fiscal_year_week
+
+    BusinessTime::Config.fiscal_month_offset = 7 # Australia
+    assert_equal 1, Date.parse("Jul 1, 2017").fiscal_year_week
+  end
+
+  it "#fiscal_year_quarter" do
+    assert_equal 4, Date.parse("Sep 30, 2017").fiscal_year_quarter
+    assert_equal 1, Date.parse("Oct 1, 2017").fiscal_year_quarter
+    assert_equal 4, Date.parse("Sep 30, 2018").fiscal_year_quarter
+
+    BusinessTime::Config.fiscal_month_offset = 7 # Australia
+    assert_equal 4, Date.parse("Jun 30, 2017").fiscal_year_quarter
+    assert_equal 1, Date.parse("Jul 1, 2017").fiscal_year_quarter
+  end
+
+  it "#fiscal_year" do
+    assert_equal 2017, Date.parse("Sep 30, 2017").fiscal_year
+    assert_equal 2018, Date.parse("Oct 1, 2017").fiscal_year
+    assert_equal 2018, Date.parse("Sep 30, 2018").fiscal_year
+
+    BusinessTime::Config.fiscal_month_offset = 7 # Australia
+    assert_equal 2017, Date.parse("Jun 30, 2017").fiscal_year
+    assert_equal 2018, Date.parse("Jul 1, 2017").fiscal_year
+  end
+
+  it "#fiscal_year_yday" do
+    assert_equal 365, Date.parse("Sep 30, 2017").fiscal_year_yday
+    assert_equal   1, Date.parse("Oct 1, 2017").fiscal_year_yday
+    assert_equal  92, Date.parse("Dec 31, 2017").fiscal_year_yday
+
+    BusinessTime::Config.fiscal_month_offset = 7 # Australia
+    assert_equal 365, Date.parse("Jun 30, 2017").fiscal_year_yday
+    assert_equal   1, Date.parse("Jul 1, 2017").fiscal_year_yday
+  end
 end


### PR DESCRIPTION
This adapts fiscal methods we used to use in activewarehouse gem into business_time, being fiscal year methods, business time seemed the most logical gem to put them in.

Includes tests, and link to original source that inspired this code. We currently use a fork of business time and would love to use the main branch. I've modified our code off business_time master and adapted the code to use business time's config.