### PR TITLE
Ruby 2.4 resolved deprecation of Fixnum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.1.5
   - 2.2.0
   - 2.3.0
+  - 2.4.0
   - jruby
 before_install:
  - gem update bundler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,23 +2,22 @@ PATH
   remote: .
   specs:
     business_time (0.7.6)
-      activesupport (>= 3.1.0)
+      activesupport (~> 4.2.8)
       tzinfo
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.0.1)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+    activesupport (4.2.8)
       i18n (~> 0.7)
       minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    concurrent-ruby (1.0.4)
-    i18n (0.7.0)
+    i18n (0.8.1)
     minitest (5.10.1)
-    minitest-rg (5.1.0)
+    minitest-rg (5.2.0)
       minitest (~> 5.0)
-    rake (10.4.2)
+    rake (12.0.0)
     rdoc (5.0.0)
     thread_safe (0.3.5)
     tzinfo (1.2.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,20 +8,18 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.6)
+    activesupport (5.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    concurrent-ruby (1.0.4)
     i18n (0.7.0)
-    json (1.8.2)
-    minitest (5.5.1)
+    minitest (5.10.1)
     minitest-rg (5.1.0)
       minitest (~> 5.0)
     rake (10.4.2)
-    rdoc (4.2.0)
-      json (~> 1.4)
+    rdoc (5.0.0)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -37,4 +35,4 @@ DEPENDENCIES
   rdoc
 
 BUNDLED WITH
-   1.11.2
+   1.13.7

--- a/business_time.gemspec
+++ b/business_time.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = `git ls-files -- {lib,rails_generators,LICENSE,README.rdoc}`.split("\n")
 
-  s.add_dependency('activesupport','>= 3.1.0')
+  s.add_dependency('activesupport','~> 4.2.8')
   s.add_dependency("tzinfo")
 
   s.add_development_dependency "rake"

--- a/lib/business_time.rb
+++ b/lib/business_time.rb
@@ -7,7 +7,7 @@ require 'yaml'
 require 'business_time/config'
 require 'business_time/business_hours'
 require 'business_time/business_days'
-require 'business_time/core_ext/fixnum'
+require 'business_time/core_ext/integer'
 
 require 'business_time/time_extensions'
 require 'business_time/core_ext/date'

--- a/lib/business_time/core_ext/integer.rb
+++ b/lib/business_time/core_ext/integer.rb
@@ -1,9 +1,9 @@
-# hook into fixnum so we can say things like:
+# hook into Integer so we can say things like:
 #  5.business_hours.from_now
 #  7.business_days.ago
 #  3.business_days.after(some_date)
 #  4.business_hours.before(some_date_time)
-class Fixnum
+class Integer
   def business_hours
     BusinessTime::BusinessHours.new(self)
   end


### PR DESCRIPTION
Replace references to `Fixnum` with `Integer`, to fix the existing deprecation warning:

> business_time-0.7.6/lib/business_time/core_ext/fixnum.rb:6: warning: constant ::Fixnum is deprecated