### PR TITLE
Resolve 2.4.0 warnings in safe backwards compatible way

### DIFF
--- a/lib/business_time/core_ext/fixnum.rb
+++ b/lib/business_time/core_ext/fixnum.rb
@@ -1,9 +1,9 @@
-# hook into fixnum so we can say things like:
+# hook into fixnum/integer so we can say things like:
 #  5.business_hours.from_now
 #  7.business_days.ago
 #  3.business_days.after(some_date)
 #  4.business_hours.before(some_date_time)
-class Fixnum
+Module.new do
   def business_hours
     BusinessTime::BusinessHours.new(self)
   end
@@ -13,4 +13,8 @@ class Fixnum
     BusinessTime::BusinessDays.new(self)
   end
   alias_method :business_day, :business_days
+end.tap do |extension_module|
+  (0.class.to_s == "Fixnum" ? Fixnum : Integer).class_exec do
+    include extension_module
+  end
 end


### PR DESCRIPTION
Like tom-lord (#148), I wanted to resolve Ruby 2.4 `Fixnum` warnings. This method is more backwards compatible and uses detection to figure out which class (`Fixnum` or `Integer`) should be extended.