### PR TITLE
Rails 5 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,17 +2,18 @@ PATH
   remote: .
   specs:
     business_time (0.9.0)
-      activesupport (~> 4.2.8)
+      activesupport (>= 3.1.0)
       tzinfo
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.8)
+    activesupport (5.0.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    concurrent-ruby (1.0.5)
     i18n (0.8.1)
     minitest (5.10.1)
     minitest-rg (5.2.0)

--- a/business_time.gemspec
+++ b/business_time.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = `git ls-files -- {lib,rails_generators,LICENSE,README.rdoc}`.split("\n")
 
-  s.add_dependency('activesupport','~> 4.2.8')
+  s.add_dependency('activesupport','>= 3.1.0')
   s.add_dependency("tzinfo")
 
   s.add_development_dependency "rake"


### PR DESCRIPTION
Reverting commit 431a726d49 that had removed support for Rails 5. It's not necessary to have compatibility with Ruby 2.4.