### PR TITLE
Restore compatibility with Rails 5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     business_time (0.9.0)
-      activesupport (~> 4.2.8)
+      activesupport (>= 4.2.8)
       tzinfo
 
 GEM

--- a/business_time.gemspec
+++ b/business_time.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = `git ls-files -- {lib,rails_generators,LICENSE,README.rdoc}`.split("\n")
 
-  s.add_dependency('activesupport','~> 4.2.8')
+  s.add_dependency('activesupport','>= 4.2.8')
   s.add_dependency("tzinfo")
 
   s.add_development_dependency "rake"


### PR DESCRIPTION
This allows business_time to be used in a Rails 5 app, which has not been possible since https://github.com/bokmann/business_time/pull/148 due to the activesupport dependency change to "~> 4.2.8".

https://github.com/bokmann/business_time/pull/153 aimed to do the same thing but reverted the activesupport gem update to 4+.