### PR TITLE
Docs: Help people upgrade to 0.9.0 by helping them find the release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,87 @@
+# Changelog
+
+## Unreleased
+
+PR authors, please add entries here.
+
+## 0.9.0 2017-04-02
+
+- PR#143 - performance improvements on hour date calculations
+- PR#144 - new feature - Fiscal date methods.
+
+## 0.8.0 2017-04-01
+
+- Ruby 2.4 compatibility 4/1/2017 (yes, this is the same as 0.9.0)
+  I released the 2.4 upgrade separately than the other new features
+  so that people have an upgrade path to 2.4 without mixing in new
+  features.
+- Forces a particular date format for Regex
+- A small change to include the version number in the project itself.
+
+## 0.7.6 2016-06-09
+
+- Fixed a defect where timezone was not preserved when dealing with
+  beginning_or_workday and end_of_workday. Thanks bazzargh.
+
+## 0.7.5 2016-04-05
+
+No documentation yet, contributions welcome.
+
+## 0.7.4 2015-04-12
+
+No documentation yet, contributions welcome.
+
+## 0.7.3 2014-06-10
+
+No documentation yet, contributions welcome.
+
+## 0.7.2 2014-03-26
+
+No documentation yet, contributions welcome.
+
+## 0.7.1 2014-02-07
+
+- fixing a multithreaded issue, upgrading some dependencies, loosening the 
+  dependency on TZInfo
+
+## 0.7.0 2014-01-27
+
+- major maintenance upgrade on the process of constructing the gem, testing 
+  the gem, and updating dependencies. the api has not changed.
+
+## 0.6.2 2013-08-12
+
+- rchady pointed out that issue #14 didn't appear to be released.  This fixes
+  that, as well as confirms that all tests run as expected on Ruby 2.0.0p195
+
+## 0.6.1 2012-04-12
+
+No documentation yet, contributions welcome.
+
+## 0.4.0 2012-01-25
+
+No documentation yet, contributions welcome.
+
+## 0.3.1 2010-12-22
+
+No documentation yet, contributions welcome.
+
+## 0.3.0 2010-05-30
+
+No documentation yet, contributions welcome.
+
+## 0.2.2 2010-04-25
+
+No documentation yet, contributions welcome.
+
+## 0.2.1 2010-04-22
+
+No documentation yet, contributions welcome.
+
+## 0.2.0 2010-04-16
+
+No documentation yet, contributions welcome.
+
+## 0.1.0 2010-04-13
+
+No documentation yet, contributions welcome.

--- a/README.rdoc
+++ b/README.rdoc
@@ -42,7 +42,7 @@ I needed this, but taking into account business hours/days and holidays.
     1.business_day.ago
     4.business_days.ago
     8.business_days.ago
-    
+
     Date.today.workday?
     Date.parse("2015-12-09").workday?
     Date.parse("2015-12-12").workday?
@@ -163,32 +163,6 @@ Timezone relative date handling gets more and more complicated every time you lo
     # Implement long weekends if they apply to the region, eg:
     # BusinessTime::Config.holidays << holiday[:date].next_week if !holiday[:date].weekday?
   end
-
-== Releases
-
-0.9.0 - PR#143 - performance improvements on hour date calculations
-        PR#144 - new feature - Fiscal date methods.
-		
-0.8.0 - Ruby 2.4 compatibility 4/1/2017 (yes, this is the same as 0.9.0)
-        I released the 2.4 upgrade separately than the other new features
-		so that people have an upgrade path to 2.4 without mixing in new
-		features.
-        Forces a particular date format for Regex
-		A small change to include the version number in the project itself.
-		
-0.7.6 - Fixed a defect where timezone was not preserved when dealing with beginning_or_workday and end_of_workday.
-        Thanks bazzargh.
-        
-0.7.2 - 0.7.5 - many pull requests from contributors, and a changelog was not adequately kept.  I regret that.
-                git blame is your friend for diagnosing these dark days.
-                
-0.7.1 - fixing a multithreaded issue, upgrading some dependencies, loosening the dependency on TZInfo
-
-0.7.0 - major maintenance upgrade on the process of constructing the gem, testing the gem, and updating dependencies.
-        the api has not changed.
-
-
-0.6.2 - rchady pointed out that issue #14 didn't appear to be released.  This fixes that, as well as confirms that all tests run as expected on Ruby 2.0.0p195
 
 == Contributors
  * David Bock  http://github.com/bokmann


### PR DESCRIPTION
Moves the release notes out of the readme, to the conventional place, CHANGELOG.md. This will make upgrading much easier for people, because they will be able to find the release notes.

Also adds release dates, and placeholders for undocumented versions.

Thanks for the great library, been using it in production for a few years now. :heart: