### PR TITLE
Nested calls to BusinessTime::Config.with break

### DIFF
--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -138,6 +138,17 @@ describe "config" do
       assert ran
     end
 
+    it "keeps the intermediate config after inherited block" do
+      ran = false
+      BusinessTime::Config.with(:end_of_workday => "2pm") do
+        BusinessTime::Config.with(:beginning_of_workday => "1pm") do
+          ran = true
+        end
+        assert_equal BusinessTime::ParsedTime.new(14, 0), BusinessTime::Config.end_of_workday
+      end
+      assert ran
+    end
+
     it "resets config after the block" do
       ran = false
       BusinessTime::Config.with(:end_of_workday => "2pm") { ran = true }
@@ -152,6 +163,20 @@ describe "config" do
       end
       assert ran
       assert_equal BusinessTime::ParsedTime.new(17, 0), BusinessTime::Config.end_of_workday
+    end
+
+    it "resets local configs after nested errors" do
+      ran = false
+      BusinessTime::Config.with(:end_of_workday => "2pm") do
+        assert_raises RuntimeError do
+          BusinessTime::Config.with(:end_of_workday => "1pm") do
+            ran = true
+            raise
+          end
+        end
+        assert_equal BusinessTime::ParsedTime.new(14, 0), BusinessTime::Config.end_of_workday
+      end
+      assert ran
     end
 
     it 'is threadsafe' do


### PR DESCRIPTION
Example code

```ruby
def show_config(prefix)
  puts "#{prefix} holidays: #{BusinessTime::Config.holidays}, work_week: #{BusinessTime::Config.work_week}"
end

show_config('Root')
BusinessTime::Config.with(holidays: [Date.today]) do
  show_config('Level 1')
  BusinessTime::Config.with(work_week: %w[mon tue]) do
    show_config('Level 2')
  end
  show_config('Level 1')
end
show_config('Root')
```

which prints
```
Root holidays: #<SortedSet:0x007fdeaa269f40>, work_week: ["mon", "tue", "wed", "thu", "fri"]
Level 1 holidays: [Thu, 27 Jul 2017], work_week: ["mon", "tue", "wed", "thu", "fri"]
Level 2 holidays: [Thu, 27 Jul 2017], work_week: ["mon", "tue"]
Level 1 holidays: #<SortedSet:0x007fdeaa269f40>, work_week: ["mon", "tue", "wed", "thu", "fri"]
Root holidays: #<SortedSet:0x007fdeaa269f40>, work_week: ["mon", "tue", "wed", "thu", "fri"]
```

Notice that the level-1 block has lost its local config.