### PR TITLE
Bugfix adding business time on a non-workday, after work hours

### DIFF
--- a/lib/business_time/business_days.rb
+++ b/lib/business_time/business_days.rb
@@ -37,6 +37,10 @@ module BusinessTime
     end
 
     def calculate_after(time, days)
+      if !time.workday? && time > Time.end_of_workday(time)
+        time = Time.beginning_of_workday(time)
+      end
+
       while days > 0 || !time.workday?
         days -= 1 if time.workday?
         time += 1.day

--- a/test/test_business_days.rb
+++ b/test/test_business_days.rb
@@ -63,6 +63,20 @@ describe "business days" do
         assert_equal expected, later
       end
 
+      it "should move to tuesday if we add one business day during a weekend, after work hours" do
+        saturday = Time.parse("April 10th, 2010, 9:00 pm")
+        later = 1.business_days.after(saturday)
+        expected = Time.parse("April 13th, 2010, 9:00 am")
+        assert_equal expected, later
+      end
+
+      it "should move to tuesday if we add one business day during a weekend, before work hours" do
+        saturday = Time.parse("April 10th, 2010, 6:00 am")
+        later = 1.business_days.after(saturday)
+        expected = Time.parse("April 13th, 2010, 9:00 am")
+        assert_equal expected, later
+      end
+
       it "should return a business hour when adding one business day from before business hours" do
         wednesday = Time.parse("Wednesday October 14th, 2015, 01:54 am")
         later = 1.business_days.after(wednesday)

--- a/test/test_business_days_utc.rb
+++ b/test/test_business_days_utc.rb
@@ -26,6 +26,20 @@ describe "business days" do
         assert_equal expected, after
       end
 
+      it "moves forward correctly when beginning on a weekend, after work hours" do
+        first = Time.zone.parse('2017-01-07 19:55:29.842345')
+        after = 3.business_day.after(first)
+        expected = Time.zone.parse("January 12th, 2017, 9:00 am")
+        assert_equal expected, after
+      end
+
+      it "moves forward correctly when beginning on a weekend, before work hours" do
+        first = Time.zone.parse("January 7th, 2010, 3:30 am")
+        after = 3.business_day.after(first)
+        expected = Time.zone.parse("January 12th, 2010, 9:00 am")
+        assert_equal expected, after
+      end
+
       it "take into account the weekend when subtracting a day" do
         first = Time.zone.parse("April 12th, 2010, 12:33 pm")
         before = 1.business_day.before(first)

--- a/test/test_business_hours.rb
+++ b/test/test_business_hours.rb
@@ -45,10 +45,24 @@ describe "business hours" do
         assert_equal expected, monday_morning
       end
 
+      it "take into account a weekend and being after work hours when adding an hour, using the common interface #since" do
+        friday_afternoon = Time.parse("April 9th 2010, 8:50 pm")
+        monday_morning = 1.business_hour.since(friday_afternoon)
+        expected = Time.parse("April 12th 2010, 10:00 am")
+        assert_equal expected, monday_morning
+      end
+
       it "take into account a weekend when subtracting an hour" do
         monday_morning = Time.parse("April 12th 2010, 9:50 am")
         friday_afternoon = 1.business_hour.before(monday_morning)
         expected = Time.parse("April 9th 2010, 4:50 pm")
+        assert_equal expected, friday_afternoon
+      end
+
+      it "take into account a weekend and being after work hours when subtracting an hour" do
+        monday_morning = Time.parse("April 12th 2010, 6:50 am")
+        friday_afternoon = 1.business_hour.before(monday_morning)
+        expected = Time.parse("April 9th 2010, 4:00 pm")
         assert_equal expected, friday_afternoon
       end
 


### PR DESCRIPTION
If we want, e.g., 3 business days after Saturday at 7pm, that should be Thursday at 9am, not Friday at 9 am.

This change preserves existing behaviour whereby, if we want 3 business days after Saturday at 11am, we will get Thursday at 11am. This seems slightly counter-intuitive, but preserves backwards compatibility.

Fixes #149 

Happy to add more tests if desirable.