### PR TITLE
Improves the business day calculation for non-business days

### DIFF
--- a/lib/business_time/business_days.rb
+++ b/lib/business_time/business_days.rb
@@ -37,6 +37,9 @@ module BusinessTime
     end
 
     def calculate_after(time, days)
+      if (time.is_a?(Time) || time.is_a?(DateTime)) && !time.workday?
+        time = Time.beginning_of_workday(time)
+      end
       while days > 0 || !time.workday?
         days -= 1 if time.workday?
         time += 1.day
@@ -50,6 +53,9 @@ module BusinessTime
     end
 
     def calculate_before(time, days)
+      if (time.is_a?(Time) || time.is_a?(DateTime)) && !time.workday?
+        time = Time.beginning_of_workday(time)
+      end
       while days > 0 || !time.workday?
         days -= 1 if time.workday?
         time -= 1.day

--- a/test/test_business_days.rb
+++ b/test/test_business_days.rb
@@ -20,14 +20,14 @@ describe "business days" do
       it "should pick next working day when adding zero days on the weekend" do
         first = Time.parse("April 10th, 2010, 12:33 pm")
         after = 0.business_days.after(first)
-        expected = Time.parse("April 12th, 2010, 12:33 pm")
+        expected = Time.parse("April 12th, 2010, 09:00 am")
         assert_equal expected, after
       end
 
       it "should pick previous working day when subtracting zero days on the weekend" do
         first = Time.parse("January 30th, 2016, 12:33 pm")
         after = 0.business_days.before(first)
-        expected = Time.parse("January 29th, 2016, 12:33 pm")
+        expected = Time.parse("January 29th, 2016, 09:00 am")
         assert_equal expected, after
       end
 
@@ -59,7 +59,14 @@ describe "business days" do
       it "should move to tuesday if we add one business day during a weekend" do
         saturday = Time.parse("April 10th, 2010, 11:00 am")
         later = 1.business_days.after(saturday)
-        expected = Time.parse("April 13th, 2010, 11:00 am")
+        expected = Time.parse("April 13th, 2010, 9:00 am")
+        assert_equal expected, later
+      end
+
+      it "should move to tuesday if we add one business day during a weekend outside normal business hours" do
+        saturday = Time.parse("April 10th, 2010, 11:55 pm")
+        later = 1.business_days.after(saturday)
+        expected = Time.parse("April 13th, 2010, 9:00 am")
         assert_equal expected, later
       end
 
@@ -73,7 +80,14 @@ describe "business days" do
       it "should move to thursday if we subtract one business day during a weekend" do
         saturday = Time.parse("April 10th, 2010, 11:00 am")
         before = 1.business_days.before(saturday)
-        expected = Time.parse("April 8th, 2010, 11:00 am")
+        expected = Time.parse("April 8th, 2010, 9:00 am")
+        assert_equal expected, before
+      end
+
+      it "should move to thursday if we subtract one business day during a weekend outside normal business hours" do
+        saturday = Time.parse("April 10th, 2010, 03:00 am")
+        before = 1.business_days.before(saturday)
+        expected = Time.parse("April 8th, 2010, 9:00 am")
         assert_equal expected, before
       end
 
@@ -156,7 +170,7 @@ describe "business days" do
       it "should move to thursday if we add one negative business day during weekend" do
         saturday = Time.parse("April 10th, 2010, 11:00 am")
         before = -1.business_days.after(saturday)
-        expected = Time.parse("April 8th, 2010, 11:00 am")
+        expected = Time.parse("April 8th, 2010, 09:00 am")
         assert_equal expected, before
       end
 
@@ -198,7 +212,7 @@ describe "business days" do
       it "should move to tuesday if we subtract one negative business day during a weekend" do
         saturday = Time.parse("April 10th, 2010, 11:00 am")
         later = -1.business_days.before(saturday)
-        expected = Time.parse("April 13th, 2010, 11:00 am")
+        expected = Time.parse("April 13th, 2010, 09:00 am")
         assert_equal expected, later
       end
 


### PR DESCRIPTION
I would like to make some changes to deal with calculation of `before` and `after` number of business days for times on non-business days.

The first problem I saw with existing behavior is apparently a bug, _0 business days before early morning on Saturday_ is one day before _0 business days before late night on Friday_: 
```
0.business_days.before(Time.parse("Sat, 16 Dec 2017 00:30:00"))
=> 2017-12-14 09:00:00 -0800
0.business_days.before(Time.parse("Fri, 15 Dec 2017 23:30:00"))
=> 2017-12-15 09:00:00 -0800
```

The second problem is that the existing code takes into account the actual hours on weekends:
```
0.business_days.before(Time.parse("Sat, 16 Dec 2017 09:30:00"))
=> 2017-12-15 09:30:00 -0800
```
I think the correct logic should simply discard that, because 0 business day before anytime of a weekend should be the previous Friday