### PR TITLE
Forced workdays

### DIFF
--- a/lib/business_time/config.rb
+++ b/lib/business_time/config.rb
@@ -8,6 +8,7 @@ module BusinessTime
   class Config
     DEFAULT_CONFIG = {
       holidays:              SortedSet.new,
+      forced_workdays:       SortedSet.new,
       beginning_of_workday:  ParsedTime.parse('9:00 am'),
       end_of_workday:        ParsedTime.parse('5:00 pm'),
       work_week:             %w(mon tue wed thu fri),
@@ -104,6 +105,12 @@ module BusinessTime
     # someplace in the initializers of your application.
     threadsafe_cattr_accessor :holidays
 
+    # You can set this yourself, either by the load method below, or
+    # by saying
+    #   BusinessTime::Config.forced_workdays << my_forced_workday_date_object
+    # someplace in the initializers of your application.
+    threadsafe_cattr_accessor :forced_workdays
+
     # working hours for each day - if not set using global variables :beginning_of_workday
     # and end_of_workday. Keys will be added ad weekdays.
     # Example:
@@ -173,6 +180,10 @@ module BusinessTime
 
         (config["holidays"] || []).each do |holiday|
           holidays << Date.parse(holiday)
+        end
+
+        (config["forced_workdays"] || []).each do |forced_workday|
+          forced_workdays << Date.parse(forced_workday)
         end
       end
 

--- a/lib/business_time/time_extensions.rb
+++ b/lib/business_time/time_extensions.rb
@@ -3,7 +3,8 @@ module BusinessTime
     # True if this time is on a workday (between 00:00:00 and 23:59:59), even if
     # this time falls outside of normal business hours.
     def workday?
-      weekday? && !BusinessTime::Config.holidays.include?(to_date)
+      BusinessTime::Config.forced_workdays.include?(self) ||
+        (weekday? && !BusinessTime::Config.holidays.include?(to_date))
     end
 
     # True if this time falls on a weekday.

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -93,6 +93,17 @@ describe "config" do
     assert !Time.parse('2012-05-07').workday?
   end
 
+  it "include forced workdays read from YAML config file" do
+    yaml = <<-YAML
+      business_time:
+        forced_workdays:
+          - April 28th, 2018
+    YAML
+    config_file = StringIO.new(yaml.gsub!(/^    /, ''))
+    BusinessTime::Config.load(config_file)
+    assert BusinessTime::Config.forced_workdays.to_a == [Date.new(2018, 4, 28)]
+  end
+
   it "use defaults for values missing in YAML file" do
     yaml = <<-YAML
     business_time:

--- a/test/test_date_extensions.rb
+++ b/test/test_date_extensions.rb
@@ -30,6 +30,13 @@ describe "date extensions" do
     assert(!july_5.workday?)
   end
 
+  it "know a forced_workday is a workday" do
+    april_28 = Date.parse("April 28, 2018")
+    assert(!april_28.workday?)
+    BusinessTime::Config.forced_workdays << april_28
+    assert(april_28.workday?)
+  end
+
   it "#week" do
     assert_equal  1, Date.parse("Jan 1, 2017").week
     assert_equal  1, Date.parse("Jan 7, 2017").week


### PR DESCRIPTION
Sometimes because of the holidays  (at least in Russia), working days for the weekend can be moved back.
For example, because of the holiday on May 1, Saturday April 29 was a working day despite the fact that the 5-day working week was in the config.
date.workday? method returned false for this date. I want to be able to specify "forced_workdays" for such cases.
It works like a holidays option

```ruby
workday = Date.parse("2018-4-29")
BusinessTime::Config.forced_workdays << workday
```

or for YAML config
```yaml
business_time:
  forced_workdays:
    - April, 28, 2018
```