### PR TITLE
PreseTime class add methods to_time, to_datetime, strftime

### DIFF
--- a/lib/business_time/parsed_time.rb
+++ b/lib/business_time/parsed_time.rb
@@ -19,6 +19,10 @@ module BusinessTime
       new(time.hour, time.min, time.sec)
     end
 
+    def strftime(option)
+      to_time.strftime(option)
+    end
+
     def to_s
       "#{hour}:#{min}:#{sec}"
     end

--- a/lib/business_time/parsed_time.rb
+++ b/lib/business_time/parsed_time.rb
@@ -23,6 +23,14 @@ module BusinessTime
       "#{hour}:#{min}:#{sec}"
     end
 
+    def to_time
+      Time.parse(to_s)
+    end
+
+    def to_datetime
+      DateTime.parse(to_s)
+    end
+
     def -(other)
       (hour - other.hour) * 3600 + (min - other.min) * 60 + sec - other.sec
     end

--- a/test/test_parsed_time.rb
+++ b/test/test_parsed_time.rb
@@ -47,6 +47,12 @@ module BusinessTime
       end
     end
 
+    describe "strftime" do
+      it "return hh:mm:ss" do
+        assert_equal ParsedTime.new(9, 8, 7).strftime("%I:%M:%S"), "09:08:07"
+      end
+    end
+
     describe "to_s" do
       it "returns hh:mm:ss" do
         assert_equal ParsedTime.new(9, 10, 11).to_s, "9:10:11"

--- a/test/test_parsed_time.rb
+++ b/test/test_parsed_time.rb
@@ -53,6 +53,18 @@ module BusinessTime
       end
     end
 
+   describe "to_time" do
+      it "returns Time class" do
+        assert_equal ParsedTime.new(9, 10, 11).to_time, Time.parse("9:10:11")
+      end
+    end
+
+   describe "to_datetime" do
+      it "returns DateTime class" do
+        assert_equal ParsedTime.new(9, 10, 11).to_datetime, DateTime.parse("9:10:11")
+      end
+    end
+
     describe "-" do
       it "returns the time difference in seconds" do
         parsed_time1 = ParsedTime.new(9, 10, 11)


### PR DESCRIPTION
# background
I would like to use date end of workday. like time object.

```
BusinessTime::Config.beginning_of_workday.strftime("at %I:%M")
```

so I add `strftime` method.
Also I thought `BusinessTime::ParsedTime` should be return Time or DateTime object.
it has hour, min, sec, but it cannot use simiilar to use Time or DateTime. 
So, I add to_time, to_datetime method :)