### PR TITLE
🚨 Fix warnings

### DIFF
--- a/gemfiles/active_support_3.gemfile
+++ b/gemfiles/active_support_3.gemfile
@@ -3,4 +3,5 @@ gemspec :path => '../'
 
 group :development, :test do
   gem 'activesupport', '~> 3.0'
+  gem 'tzinfo', '~> 1.2'
 end

--- a/lib/business_time/config.rb
+++ b/lib/business_time/config.rb
@@ -80,23 +80,7 @@ module BusinessTime
       end
     end
 
-    # You can set this yourself, either by the load method below, or
-    # by saying
-    #   BusinessTime::Config.beginning_of_workday = "8:30 am"
-    # someplace in the initializers of your application.
-    threadsafe_cattr_reader :beginning_of_workday
-
-    # You can set this yourself, either by the load method below, or
-    # by saying
-    #   BusinessTime::Config.end_of_workday = "5:30 pm"
-    # someplace in the initializers of your application.
-    threadsafe_cattr_reader :end_of_workday
-
-    # You can set this yourself, either by the load method below, or
-    # by saying
-    #   BusinessTime::Config.work_week = [:sun, :mon, :tue, :wed, :thu]
-    # someplace in the initializers of your application.
-    threadsafe_cattr_accessor :work_week
+    threadsafe_cattr_reader :work_week
 
     # You can set this yourself, either by the load method below, or
     # by saying
@@ -118,6 +102,10 @@ module BusinessTime
     threadsafe_cattr_accessor :fiscal_month_offset
 
     class << self
+      # You can set this yourself, either by the load method below, or
+      # by saying
+      #   BusinessTime::Config.end_of_workday = "5:30 pm"
+      # someplace in the initializers of your application.
       def end_of_workday(day=nil)
         if day
           wday = work_hours[int_to_wday(day.wday)]
@@ -127,6 +115,10 @@ module BusinessTime
         end
       end
 
+      # You can set this yourself, either by the load method below, or
+      # by saying
+      #   BusinessTime::Config.beginning_of_workday = "8:30 am"
+      # someplace in the initializers of your application.
       def beginning_of_workday(day=nil)
         if day
           wday = work_hours[int_to_wday(day.wday)]
@@ -136,6 +128,10 @@ module BusinessTime
         end
       end
 
+      # You can set this yourself, either by the load method below, or
+      # by saying
+      #   BusinessTime::Config.work_week = [:sun, :mon, :tue, :wed, :thu]
+      # someplace in the initializers of your application.
       def work_week=(days)
         config[:work_week] = days
         self._weekdays = nil

--- a/test/test_business_days.rb
+++ b/test/test_business_days.rb
@@ -237,7 +237,7 @@ describe "business days" do
       assert 5.business_days < 10.business_days
       assert !(10.business_days < 5.business_days)
 
-      assert -1.business_day < 1.business_day
+      assert(-1.business_day < 1.business_day)
       assert !(1.business_day < -1.business_day)
     end
 
@@ -253,8 +253,8 @@ describe "business days" do
       assert 5.business_days == 5.business_days
       assert 10.business_days != 5.business_days
 
-      assert -1.business_day == -1.business_day
-      assert -1.business_day != -5.business_days
+      assert(-1.business_day == -1.business_day)
+      assert(-1.business_day != -5.business_days)
     end
 
     it "won't compare days to hours" do

--- a/test/test_business_hours.rb
+++ b/test/test_business_hours.rb
@@ -220,7 +220,7 @@ describe "business hours" do
       it "consider any time on a weekend as equivalent to monday morning" do
         sunday = Time.parse("Sun Apr 25 12:06:56, 2010")
         monday = Time.parse("Mon Apr 26, 09:00:00, 2010")
-        assert_equal -1.business_hour.before(monday), -1.business_hour.before(sunday)
+        assert_equal(-1.business_hour.before(monday), -1.business_hour.before(sunday))
       end
 
       it "respect work_hours" do
@@ -286,10 +286,10 @@ describe "business hours" do
       assert 5.business_hours < 10.business_hours
       assert !(10.business_hours < 5.business_hours)
 
-      assert -10.business_hours < -5.business_hours
+      assert(-10.business_hours < -5.business_hours)
       assert !(-5.business_hours < -10.business_hours)
 
-      assert -5.business_hours < 5.business_hours
+      assert(-5.business_hours < 5.business_hours)
       assert !(5.business_hours < -5.business_hours)
     end
 
@@ -298,7 +298,7 @@ describe "business hours" do
       assert 10.business_hours > 5.business_hours
 
       assert !(-10.business_hours > -5.business_hours)
-      assert -5.business_hours > -10.business_hours
+      assert(-5.business_hours > -10.business_hours)
 
       assert !(-5.business_hours > 5.business_hours)
       assert 5.business_hours > -5.business_hours
@@ -308,10 +308,10 @@ describe "business hours" do
       assert 5.business_hours == 5.business_hours
       assert 10.business_hours != 5.business_hours
 
-      assert -5.business_hours == -5.business_hours
-      assert -5.business_hours != -10.business_hours
+      assert(-5.business_hours == -5.business_hours)
+      assert(-5.business_hours != -10.business_hours)
 
-      assert -5.business_hours != 5.business_hours
+      assert(-5.business_hours != 5.business_hours)
     end
 
     it "won't compare hours and days" do

--- a/test/test_business_hours_eastern.rb
+++ b/test/test_business_hours_eastern.rb
@@ -116,7 +116,7 @@ describe "business hours" do
       it "consider any time on a weekend as equivalent to monday morning" do
         sunday = Time.zone.parse("Sun Apr 25 12:06:56, 2010")
         monday = Time.zone.parse("Mon Apr 26, 09:00:00, 2010")
-        assert_equal -1.business_hour.before(monday), -1.business_hour.before(sunday)
+        assert_equal(-1.business_hour.before(monday), -1.business_hour.before(sunday))
       end
     end
   end

--- a/test/test_business_hours_utc.rb
+++ b/test/test_business_hours_utc.rb
@@ -4,7 +4,7 @@ describe "business hours" do
   describe "with a TimeWithZone object in UTC" do
     before { Time.zone = 'UTC' }
 
-    describe "when adding/subtracting positive business hours" do 
+    describe "when adding/subtracting positive business hours" do
       it "move to tomorrow if we add 8 business hours" do
         first = Time.zone.parse("Aug 4 2010, 9:35 am")
         later = 8.business_hours.after(first)
@@ -114,7 +114,7 @@ describe "business hours" do
       it "consider any time on a weekend as equivalent to monday morning" do
         sunday = Time.zone.parse("Sun Apr 25 12:06:56, 2010")
         monday = Time.zone.parse("Mon Apr 26, 09:00:00, 2010")
-        assert_equal -1.business_hour.before(monday), -1.business_hour.before(sunday)
+        assert_equal(-1.business_hour.before(monday), -1.business_hour.before(sunday))
       end
     end
   end

--- a/test/test_calculating_consecutive_days.rb
+++ b/test/test_calculating_consecutive_days.rb
@@ -3,7 +3,7 @@ require File.expand_path('../helper', __FILE__)
 describe 'calculating consecutive workdays' do
   it 'return empty array if object is not a workday' do
     sunday = Date.parse("December 26, 2010")
-    sunday.consecutive_workdays.must_equal []
+    _(sunday.consecutive_workdays).must_equal []
   end
 
   it 'return array with self if preceded and followed by non-working days' do
@@ -27,7 +27,7 @@ end
 describe 'calculating consecutive non-working days' do
   it 'return empty array if object is not a non-working day' do
     monday = Date.parse("December 13, 2010")
-    monday.consecutive_non_working_days.must_equal []
+    _(monday.consecutive_non_working_days).must_equal []
   end
 
   it 'return array with self if preceded and followed by workdays' do


### PR DESCRIPTION
## What does it do?

- Fix warnings for ambiguous `-` operator usage
- Fix minitest deprecation warning
- Remove duplicate definitions of config properties

## What else do you need to know?

business_time was generating syntax and deprecation warnings.

```
.../business_time/test/test_business_days.rb:240: warning: ambiguous first argument; put parentheses or a space even after `-' operator
.../business_time/test/test_business_days.rb:256: warning: ambiguous first argument; put parentheses or a space even after `-' operator
.../business_time/test/test_business_days.rb:257: warning: ambiguous first argument; put parentheses or a space even after `-' operator
.../business_time/lib/business_time/config.rb:121: warning: method redefined; discarding old end_of_workday
.../business_time/lib/business_time/config.rb:71: warning: previous definition of end_of_workday was here
.../business_time/lib/business_time/config.rb:130: warning: method redefined; discarding old beginning_of_workday
.../business_time/lib/business_time/config.rb:71: warning: previous definition of beginning_of_workday was here
.../business_time/lib/business_time/config.rb:139: warning: method redefined; discarding old work_week=
.../business_time/lib/business_time/config.rb:77: warning: previous definition of work_week= was here
.../business_time/test/test_business_hours.rb:223: warning: ambiguous first argument; put parentheses or a space even after `-' operator
.../business_time/test/test_business_hours.rb:289: warning: ambiguous first argument; put parentheses or a space even after `-' operator
.../business_time/test/test_business_hours.rb:292: warning: ambiguous first argument; put parentheses or a space even after `-' operator
.../business_time/test/test_business_hours.rb:301: warning: ambiguous first argument; put parentheses or a space even after `-' operator
.../business_time/test/test_business_hours.rb:311: warning: ambiguous first argument; put parentheses or a space even after `-' operator
.../business_time/test/test_business_hours.rb:312: warning: ambiguous first argument; put parentheses or a space even after `-' operator
.../business_time/test/test_business_hours.rb:314: warning: ambiguous first argument; put parentheses or a space even after `-' operator
.../business_time/test/test_business_hours_eastern.rb:119: warning: ambiguous first argument; put parentheses or a space even after `-' operator
.../business_time/test/test_business_hours_utc.rb:117: warning: ambiguous first argument; put parentheses or a space even after `-' operator
```
 