### PR TITLE
[Fix] workday?, weekday? to return bool instead of true or nil

### DIFF
--- a/lib/business_time/time_extensions.rb
+++ b/lib/business_time/time_extensions.rb
@@ -8,7 +8,7 @@ module BusinessTime
 
     # True if this time falls on a weekday.
     def weekday?
-      BusinessTime::Config.weekdays.include?(wday)
+      !!BusinessTime::Config.weekdays.include?(wday)
     end
 
     module ClassMethods


### PR DESCRIPTION
Hello. I'm Brown.
It seems that workday?, weekday? return 'true' or 'nil' instead of false.
```
irb(main):009:0> RUBY_VERSION
=> "2.6.6"
```

```
irb(main):010:0> today = Date.current
=> Wed, 26 May 2021
irb(main):011:0> sunday = today + 3.days
=> Sat, 29 May 2021
irb(main):012:0> today.weekday?
=> true
irb(main):013:0> today.workday?
=> true

irb(main):015:0> sunday.weekday?
=> nil
irb(main):016:0> sunday.workday?
=> nil
```

It is because `{SortedSet}.include?()` returns true or nil
```
irb(main):020:0> BusinessTime::Config.weekdays
=> #<SortedSet: {1, 2, 3, 4, 5}>

irb(main):017:0> a = SortedSet.new([1,2])
=> #<SortedSet: {1, 2}>
irb(main):018:0> a.include?(2)
=> true
irb(main):019:0> a.include?(3)
=> nil
```

How about changing these two methods to return true or false like this?
```
irb(main):003:0> today = Date.current
=> Wed, 26 May 2021
irb(main):004:0> sunday = today + 3.days
=> Sat, 29 May 2021
irb(main):005:0> today.weekday?
=> true
irb(main):006:0> today.workday?
=> true
irb(main):007:0> sunday.weekday?
=> false
irb(main):008:0> sunday.workday?
=> false
```

related issue:
https://github.com/knu/sorted_set/issues/2