### PR TITLE
Remove dependency on SortedSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com//), and thi
 ## [Unreleased] - TBD
 
 - Update build matrix for ActiveSupport 7 support (#215)
+- Remove dependency on sorted_set and rbtree (#214)
+
+Both `BusinessTime::Config.holidays` and `BusinessTime::Config.weekdays` now
+return a `Set` instead of a `SortedSet`.
+
+Warning: `BusinessTime::Config.holidays` no longer keeps holidays in sorted
+order. If you rely on `holidays` returning in sorted order, please be sure to
+load them in sorted order.
 
 ## [0.11.0] - 2021-11-22
 

--- a/business_time.gemspec
+++ b/business_time.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency("activesupport", ">= 3.2.0")
   s.add_dependency("tzinfo")
-  s.add_dependency("sorted_set") # for Ruby 3 support
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rdoc"

--- a/lib/business_time.rb
+++ b/lib/business_time.rb
@@ -1,8 +1,9 @@
-require 'thread'
-require 'active_support'
-require 'active_support/time'
+require 'set'
 require 'time'
 require 'yaml'
+
+require 'active_support'
+require 'active_support/time'
 
 require 'business_time/parsed_time'
 require 'business_time/version'

--- a/lib/business_time/config.rb
+++ b/lib/business_time/config.rb
@@ -7,7 +7,7 @@ module BusinessTime
   # manually, or with a yaml file and the load method.
   class Config
     DEFAULT_CONFIG = {
-      holidays:              SortedSet.new,
+      holidays:              Set.new,
       beginning_of_workday:  ParsedTime.parse('9:00 am'),
       end_of_workday:        ParsedTime.parse('5:00 pm'),
       work_week:             %w(mon tue wed thu fri),
@@ -144,7 +144,7 @@ module BusinessTime
           wday_to_int(day_name)
         end.compact
 
-        self._weekdays = SortedSet.new(days)
+        self._weekdays = Set.new(days.sort)
       end
 
       # loads the config data from a yaml file written as:

--- a/lib/business_time/config.rb
+++ b/lib/business_time/config.rb
@@ -144,7 +144,7 @@ module BusinessTime
           wday_to_int(day_name)
         end.compact
 
-        self._weekdays = Set.new(days.sort)
+        self._weekdays = days.sort.to_set
       end
 
       # loads the config data from a yaml file written as:

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -27,11 +27,12 @@ describe "config" do
   end
 
   it "map work week to weekdays" do
-    assert_equal SortedSet.new([1,2,3,4,5]), BusinessTime::Config.weekdays
-    BusinessTime::Config.work_week = %w[sun mon tue wed thu]
-    assert_equal SortedSet.new([0,1,2,3,4]), BusinessTime::Config.weekdays
+    assert_equal Set.new([1,2,3,4,5]), BusinessTime::Config.weekdays
+    BusinessTime::Config.work_week = %w[thu mon sun tue wed]
+    assert_equal Set.new([0,1,2,3,4]), BusinessTime::Config.weekdays
+    assert_equal [0,1,2,3,4], BusinessTime::Config.weekdays.to_a
     BusinessTime::Config.work_week = %w[tue wed] # Hey, we got it made!
-    assert_equal SortedSet.new([2,3]), BusinessTime::Config.weekdays
+    assert_equal Set.new([2,3]), BusinessTime::Config.weekdays
   end
 
   it "keep track of the start of the day using work_hours" do
@@ -78,7 +79,7 @@ describe "config" do
     assert_equal BusinessTime::ParsedTime.new(11, 0), BusinessTime::Config.beginning_of_workday
     assert_equal BusinessTime::ParsedTime.new(14, 0), BusinessTime::Config.end_of_workday
     assert_equal ['mon'], BusinessTime::Config.work_week
-    assert_equal SortedSet.new([Date.parse('2012-12-25')]), BusinessTime::Config.holidays
+    assert_equal Set.new([Date.parse('2012-12-25')]), BusinessTime::Config.holidays
   end
 
   it "include holidays read from YAML config files" do
@@ -103,7 +104,7 @@ describe "config" do
     assert_equal BusinessTime::ParsedTime.new(9, 0), BusinessTime::Config.beginning_of_workday
     assert_equal BusinessTime::ParsedTime.new(17, 0), BusinessTime::Config.end_of_workday
     assert_equal %w[mon tue wed thu fri], BusinessTime::Config.work_week
-    assert_equal SortedSet.new, BusinessTime::Config.holidays
+    assert_equal Set.new, BusinessTime::Config.holidays
   end
 
   it "is threadsafe" do


### PR DESCRIPTION
### 🚨 This is currently an experiment. 🚨

This is an experiment open for discussion and review. I'm not yet sure that this is the best approach, but the discussion in #213 got me thinking. Less external dependencies are usually better, and I'm not sure we were gaining a ton by using `SortedSet`. Now that `SortedSet` is no longer part of core ruby, these seems like a reasonable trade-off to eliminate its usage.

## What does it do?

- Removes external dependency on `SortedSet`

## What else do you need to know?

- `SortedSet` and is no longer part of core Ruby. 
- `SortedSet` relies on `RBTree` to perform
- I don't think we were gaining anything by using a `SortedSet` vs a regular `Set`

## Related Issues

- Fixes #213  (/cc @kimyu92)

