### PR TITLE
Quote 3.0 to avoid truncation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.7, 3.0, 3.1]
+        ruby: [2.7, "3.0", 3.1]
         bundler: [default]
         gemfile:
           - active_support_6


### PR DESCRIPTION
An unquoted 3.0 will be truncated to 3.  This causes that line of the CI matrix to load the latest Ruby 3, which is currently a 3.1.x version.

Quoting the 3.0 avoids truncation and ensures that a 3.0.x version is loaded for that line.