### PR TITLE
Support 11pm close times

### DIFF
--- a/test/test_business_hours.rb
+++ b/test/test_business_hours.rb
@@ -143,6 +143,19 @@ describe "business hours" do
         assert_equal friday, 24.business_hours.before(monday)
       end
 
+      it "respect work_hours with 11pm closing time" do
+        two_before_close = Time.parse("2024-09-30 21:00")
+        two_after_open = Time.parse("2024-10-01 16:00")
+
+        BusinessTime::Config.work_hours = {
+          mon: ["14:00", "23:00"],
+          tue: ["14:00", "23:00"],
+        }
+
+        assert_equal two_after_open, 4.business_hours.after(two_before_close)
+        assert_equal two_before_close, 4.business_hours.before(two_after_open)
+      end
+
       it "respect work_hours within same day" do
         friday_start = Time.parse("December 24, 2010 8:00")
         friday_end   = Time.parse("December 24, 2010 17:00")


### PR DESCRIPTION
## Why?
While working on a project where I needed to provide our hours in UTC times, I noticed a bug with 11pm closing times where an hour would be "eaten" by `business_hours.after(time)` if time was right up against the end of the work day/11pm:

```
BusinessTime::Config.beginning_of_workday = "2pm"
BusinessTime::Config.end_of_workday = "11pm"
# standard Mon-Friday work week

monday = Time.parse("2024/09/30 9:00pm")
tuesday = Time.parse("2024/10/01 4:00pm")
4.business_hours.before(tuesday) == monday # true
4.business_hours.after(monday) == tuesday # false
```

Strangely, the reverse problem didn't exist. `4.business_hours.before(<Tues@4pm>)` accurately returned Mon@9pm.

## What?
- Refactor `calculate_after`:
   - Instead of defaulting to `Time.roll_forward(after_time)` when after_time is 00:00:00, use the logic for checking if 
`after_time` is outside of work hours instead so that the `delta` isn't lost.
   - That introduced a bug with the exceptions in place for closing times of 00:00:00, so I also added a check to ignore the delta if it was only 1 second.'
- match the pattern in `calculate_before` for simplicity.