### PR TITLE
Account for config.end_of_workday=00:00:00

### DIFF
--- a/lib/business_time/config.rb
+++ b/lib/business_time/config.rb
@@ -107,12 +107,13 @@ module BusinessTime
       #   BusinessTime::Config.end_of_workday = "5:30 pm"
       # someplace in the initializers of your application.
       def end_of_workday(day=nil)
+        eod = config[:end_of_workday]
         if day
           wday = work_hours[int_to_wday(day.wday)]
-          wday ? (wday.last == ParsedTime.new(0, 0) ? ParsedTime.new(23, 59, 59) : wday.last) : config[:end_of_workday]
-        else
-          config[:end_of_workday]
+          eod = wday.last if wday
         end
+
+        eod == ParsedTime.new(0, 0) ? ParsedTime.new(23, 59, 59) : eod
       end
 
       # You can set this yourself, either by the load method below, or

--- a/test/test_business_hours.rb
+++ b/test/test_business_hours.rb
@@ -172,6 +172,17 @@ describe "business hours" do
         expected = Time.parse("July 6th 2010, 9:50 am")
         assert_equal expected, tuesday_morning
       end
+
+      it "respect end_of_workday with 12am closing time" do
+        two_before_close = Time.parse("2024-11-04 22:00")
+        two_after_open = Time.parse("2024-11-05 17:00")
+
+        BusinessTime::Config.beginning_of_workday = "3pm"
+        BusinessTime::Config.end_of_workday = "12am"
+
+        assert_equal two_after_open, 4.business_hours.after(two_before_close)
+        assert_equal two_before_close, 4.business_hours.before(two_after_open)
+      end
     end
 
     describe "when adding/subtracting negative number of business hours" do


### PR DESCRIPTION
## Why?
Was working on a project using UTC times and was testing around Daylight Savings Time when I realized that `Config.end_of_workday` had something to handle midnight closing times, but only if the hours are configured through `work_hours=` and not `end_of_workday=`

## What?
Move the "is closing time midnight? Return 1 second before that instead" check outside of the branch handling when the `day` argument is present.