### PR TITLE
Fix Roll-forward logic

### DIFF
--- a/lib/business_time/business_days.rb
+++ b/lib/business_time/business_days.rb
@@ -41,8 +41,8 @@ module BusinessTime
         time = Time.beginning_of_workday(time)
       end
       while days > 0 || !time.workday?(options)
-        days -= 1 if time.workday?(options)
         time += 1.day
+        days -= 1 if time.workday?(options)
       end
       # If we have a Time or DateTime object, we can roll_forward to the
       #   beginning of the next business day
@@ -57,8 +57,8 @@ module BusinessTime
         time = Time.beginning_of_workday(time)
       end
       while days > 0 || !time.workday?(options)
-        days -= 1 if time.workday?(options)
         time -= 1.day
+        days -= 1 if time.workday?(options)
       end
       # If we have a Time or DateTime object, we can roll_backward to the
       #   beginning of the previous business day


### PR DESCRIPTION
The logic for `calculate_before` and `calculate_after` is broken, where it will advance one day too many.  Applying the [fix by dynaum](https://github.com/dynaum/business_time/commit/35782fdc34649c6b017e321f5d1288d9faa66bdc) from the [issue in the `business_time` gem](https://github.com/bokmann/business_time/issues/114) addresses this.