### PR TITLE
Fix business days counting in before/after methods

### DIFF
--- a/lib/business_time/business_days.rb
+++ b/lib/business_time/business_days.rb
@@ -40,6 +40,7 @@ module BusinessTime
       if (time.is_a?(Time) || time.is_a?(DateTime)) && !time.workday?(options)
         time = Time.beginning_of_workday(time)
       end
+      time += 1.day  # This ensures we never count the start date itself
       while days > 0 || !time.workday?(options)
         days -= 1 if time.workday?(options)
         time += 1.day
@@ -56,6 +57,7 @@ module BusinessTime
       if (time.is_a?(Time) || time.is_a?(DateTime)) && !time.workday?(options)
         time = Time.beginning_of_workday(time)
       end
+      time -= 1.day  # This ensures we never count the start date itself
       while days > 0 || !time.workday?(options)
         days -= 1 if time.workday?(options)
         time -= 1.day


### PR DESCRIPTION
## Reference
[Issue 196 ](https://github.com/bokmann/business_time/issues/196)

## Description
### Problem:
The counting of business days is inconsistent in `before` and `after` methods depending on whether the start date is a workday or not. 

When starting on a workday:
```ruby
> 5.business_days.before(Date.new(2025, 1, 15))
=> Wed, 08 Jan 2025
```
This only counts 4 workdays (Tue 14, Mon 13, Fri 10, Thu 9), instead of 5.

But when starting on a non-workday:
```ruby
> 5.business_days.before(Date.new(2025,02,15))
=> Fri, 07 Feb 2025
```
This correctly counts 5 workdays (Fri 14, Thu 13, Wed 12, Tue 11, Mon 10).

See also https://github.com/bokmann/business_time/issues/196#issuecomment-2621003006 for a more detailed explanation.

### Solution:
Move one day first before starting the count:
```ruby
time -= 1.day  # For before()
# or
time += 1.day  # For after()
```

This ensures we never count the start date itself, making the behavior consistent in all cases.
