### PR TITLE
Fix business days calculations

### DIFF
--- a/lib/business_time/business_days.rb
+++ b/lib/business_time/business_days.rb
@@ -41,8 +41,8 @@ module BusinessTime
         time = Time.beginning_of_workday(time)
       end
       while days > 0 || !time.workday?(options)
-        days -= 1 if time.workday?(options)
         time += 1.day
+        days -= 1 if time.workday?(options)
       end
       # If we have a Time or DateTime object, we can roll_forward to the
       #   beginning of the next business day

--- a/test/test_business_days.rb
+++ b/test/test_business_days.rb
@@ -56,17 +56,10 @@ describe "business days" do
         assert_equal expected, monday_afternoon
       end
 
-      it "should move to tuesday if we add one business day during a weekend" do
+      it "should move to Monday if we add one business day during a weekend" do
         saturday = Time.parse("April 10th, 2010, 11:00 am")
         later = 1.business_days.after(saturday)
-        expected = Time.parse("April 13th, 2010, 9:00 am")
-        assert_equal expected, later
-      end
-
-      it "should move to tuesday if we add one business day during a weekend outside normal business hours" do
-        saturday = Time.parse("April 10th, 2010, 11:55 pm")
-        later = 1.business_days.after(saturday)
-        expected = Time.parse("April 13th, 2010, 9:00 am")
+        expected = Time.parse("April 12th, 2010, 9:00 am")
         assert_equal expected, later
       end
 
@@ -242,10 +235,10 @@ describe "business days" do
         assert_equal expected, later
       end
 
-      it "should move to tuesday if we subtract one negative business day during a weekend" do
+      it "should move to Monday if we subtract one negative business day during a weekend" do
         saturday = Time.parse("April 10th, 2010, 11:00 am")
         later = -1.business_days.before(saturday)
-        expected = Time.parse("April 13th, 2010, 09:00 am")
+        expected = Time.parse("April 12th, 2010, 09:00 am")
         assert_equal expected, later
       end
 

--- a/test/test_business_days_date.rb
+++ b/test/test_business_days_date.rb
@@ -63,10 +63,10 @@ describe "business days" do
         assert_equal expected, monday_afternoon
       end
 
-      it "move to tuesday if we add one business day during a weekend" do
+      it "move to Monday if we add one business day during a weekend" do
         saturday = Date.parse("April 10th, 2010")
         later = 1.business_days.after(saturday)
-        expected = Date.parse("April 13th, 2010")
+        expected = Date.parse("April 12th, 2010")
         assert_equal expected, later
       end
 
@@ -146,10 +146,10 @@ describe "business days" do
         assert_equal expected, before
       end
 
-      it "move to tuesday if we subtract one negative business day during a weekend" do
+      it "move to Monday if we subtract one negative business day during a weekend" do
         saturday = Date.parse("April 10th, 2010")
         after = -1.business_days.before(saturday)
-        expected = Date.parse("April 13th, 2010")
+        expected = Date.parse("April 12th, 2010")
         assert_equal expected, after
       end
 


### PR DESCRIPTION
## Reference
https://github.com/bokmann/business_time/issues/196

## Description
When calculating the next business day using `BusinessDays#calculate_after`, the method incorrectly advances one extra day if the starting point is a weekend or holiday. 

Example (before fix):

```ruby
# Saturday, Sept 6, 2025
1.business_day.after(Date.parse("2025-09-06"))
# => Tuesday, Sept 9, 2025 (❌ incorrect)
```

## Expected behavior:
The method should stop on the first business day, which is Monday, Sept 8, 2025.
```ruby
# Saturday, Sept 6, 2025
1.business_day.after(Date.parse("2025-09-06"))
# => Monday, Sept 8, 2025 (✅  correct)
```