### PR TITLE
Add weekend? method as complement to weekday?

### DIFF
--- a/lib/business_time/time_extensions.rb
+++ b/lib/business_time/time_extensions.rb
@@ -15,6 +15,11 @@ module BusinessTime
       BusinessTime::Config.weekdays.include?(wday)
     end
 
+    # True if this time falls on a weekend
+    def weekend?
+      !weekday?
+    end
+
     module ClassMethods
       # Gives the time at the end of the workday, assuming that this time falls on a
       # workday.

--- a/test/test_date_extensions.rb
+++ b/test/test_date_extensions.rb
@@ -16,6 +16,21 @@ describe "date extensions" do
     assert(Date.parse("April 12, 2010").weekday?)
   end
 
+  it "know a weekday is not a weekend" do
+    assert(!Date.parse("April 9, 2010").weekend?)   # Friday
+    assert( Date.parse("April 10, 2010").weekend?)  # Saturday
+    assert( Date.parse("April 11, 2010").weekend?)  # Sunday
+    assert(!Date.parse("April 12, 2010").weekend?)  # Monday
+  end
+
+  it "know a weekend is relative to the configured work week" do
+    BusinessTime::Config.work_week = %w[sun mon tue wed thu]
+    assert(!Date.parse("April 8, 2010").weekend?)   # Thursday
+    assert( Date.parse("April 9, 2010").weekend?)   # Friday — weekend under this config
+    assert( Date.parse("April 10, 2010").weekend?)  # Saturday
+    assert(!Date.parse("April 11, 2010").weekend?)  # Sunday — weekday under this config
+  end
+
   it "know a holiday is not a workday" do
     july_4 = Date.parse("July 4, 2010")
     july_5 = Date.parse("July 5, 2010")

--- a/test/test_time_extensions.rb
+++ b/test/test_time_extensions.rb
@@ -16,6 +16,26 @@ describe "time extensions" do
     assert( Time.parse("April 11, 2010 10:30am").weekday?)
   end
 
+  it "know a weekday is not a weekend" do
+    assert(!Time.parse("April 9, 2010 10:45 am").weekend?)   # Friday
+    assert( Time.parse("April 10, 2010 10:45 am").weekend?)  # Saturday
+    assert( Time.parse("April 11, 2010 10:45 am").weekend?)  # Sunday
+    assert(!Time.parse("April 12, 2010 10:45 am").weekend?)  # Monday
+  end
+
+  it "know a weekend is relative to the configured work week" do
+    BusinessTime::Config.work_week = %w[sun mon tue wed thu]
+    assert(!Time.parse("April 8, 2010 10:30am").weekend?)   # Thursday
+    assert( Time.parse("April 9, 2010 10:30am").weekend?)   # Friday — weekend under this config
+    assert( Time.parse("April 10, 2010 10:30am").weekend?)  # Saturday
+    assert(!Time.parse("April 11, 2010 10:30am").weekend?)  # Sunday — weekday under this config
+  end
+
+  it "does not consider a holiday a weekend day" do
+    BusinessTime::Config.holidays << Date.parse("July 5, 2010")  # Monday
+    assert(!Time.parse("July 5th, 2010 2:37 pm").weekend?)
+  end
+
   it "know a holiday is not a workday" do
     BusinessTime::Config.holidays << Date.parse("July 4, 2010")
     BusinessTime::Config.holidays << Date.parse("July 5, 2010")

--- a/test/test_time_with_zone_extensions.rb
+++ b/test/test_time_with_zone_extensions.rb
@@ -13,6 +13,13 @@ describe "TimeWithZone extensions" do
       assert( Time.zone.parse("April 12, 2010 10:30am").weekday?)
     end
 
+    it "know a weekday is not a weekend" do
+      assert(!Time.zone.parse("April 9, 2010 10:30am").weekend?)
+      assert( Time.zone.parse("April 10, 2010 10:30am").weekend?)
+      assert( Time.zone.parse("April 11, 2010 10:30am").weekend?)
+      assert(!Time.zone.parse("April 12, 2010 10:30am").weekend?)
+    end
+
     it "know a weekend day is not a workday" do
       assert( Time.zone.parse("April 9, 2010 10:45 am").workday?)
       assert(!Time.zone.parse("April 10, 2010 10:45 am").workday?)
@@ -59,6 +66,13 @@ describe "TimeWithZone extensions" do
       assert(!Time.zone.parse("April 10, 2010 10:30am").weekday?)
       assert(!Time.zone.parse("April 11, 2010 10:30am").weekday?)
       assert( Time.zone.parse("April 12, 2010 10:30am").weekday?)
+    end
+
+    it "know a weekday is not a weekend" do
+      assert(!Time.zone.parse("April 9, 2010 10:30am").weekend?)
+      assert( Time.zone.parse("April 10, 2010 10:30am").weekend?)
+      assert( Time.zone.parse("April 11, 2010 10:30am").weekend?)
+      assert(!Time.zone.parse("April 12, 2010 10:30am").weekend?)
     end
 
     it "know a weekend day is not a workday" do


### PR DESCRIPTION
Add a logical complementary time extension so that both `weekday?` and `weekend?` return expected boolean values. 

Of note
-  This change respects `Config.work_week` but is not affected by holidays (intentional, mirrors `weekday?` behavior)
-  Tests added for `Time`, `Date`, and `TimeWithZone` in both Eastern and UTC contexts